### PR TITLE
Feature/fe/#54 notice screen

### DIFF
--- a/front/capstone_front/.gitignore
+++ b/front/capstone_front/.gitignore
@@ -1,6 +1,9 @@
 # Do not remove or rename entries in this file, only add new ones
 # See https://github.com/flutter/flutter/issues/128635 for more context.
 
+#env
+.env
+
 # Miscellaneous
 *.class
 *.lock

--- a/front/capstone_front/lib/main.dart
+++ b/front/capstone_front/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:capstone_front/firebase_options.dart';
+import 'package:capstone_front/models/notice_model.dart';
 import 'package:capstone_front/screens/cafeteriaMenu/cafeteriaMenuScreen.dart';
 import 'package:capstone_front/screens/chatbot/chatbot.dart';
 import 'package:capstone_front/screens/faq/faq_screen.dart';
@@ -146,10 +147,15 @@ final GoRouter router = GoRouter(
     ),
     GoRoute(
       name: 'noticedetail',
-      path: '/notice/detail',
-      builder: (context, state) => NoticeDetailScreen(
-        const {"title": "temp", "date": "temp", "kind": "temp"},
-      ),
+      path: '/notice/detail/:id',
+      builder: (context, state) {
+        // 'state.extra'를 통해 전달된 'NoticeModel' 객체를 받아옴
+        final notice = state.extra as NoticeModel?;
+        if (notice == null) {
+          return const NoticeScreen();
+        }
+        return NoticeDetailScreen(notice);
+      },
     ),
     GoRoute(
       name: 'qnalist',

--- a/front/capstone_front/lib/main.dart
+++ b/front/capstone_front/lib/main.dart
@@ -22,6 +22,7 @@ import 'package:capstone_front/utils/page_animation.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -61,7 +62,7 @@ void main() async {
   initializeFirebase();
   await setSetting();
   await EasyLocalization.ensureInitialized();
-
+  await dotenv.load(fileName: ".env");
   runApp(EasyLocalization(
     // 지원 언어 리스트
     supportedLocales: supportedLocales,

--- a/front/capstone_front/lib/models/notice_model.dart
+++ b/front/capstone_front/lib/models/notice_model.dart
@@ -1,0 +1,30 @@
+class NoticeModel {
+  String? createdDate;
+  String? modifiedDate;
+  int? id;
+  String? type;
+  String? title;
+  String? writtenDate;
+  String? department;
+  String? author;
+  String? authorPhone;
+  String? document;
+  String? language;
+  String? url;
+  List<dynamic>? files;
+
+  NoticeModel.fromJson(Map<String, dynamic> json)
+      : createdDate = json['createdDate'],
+        modifiedDate = json['modifiedDate'],
+        id = json['id'],
+        type = json['type'],
+        title = json['title'],
+        writtenDate = json['writtenDate'],
+        department = json['department'],
+        author = json['author'],
+        authorPhone = json['authorPhone'],
+        document = json['document'],
+        language = json['language'],
+        url = json['url'],
+        files = json['files'];
+}

--- a/front/capstone_front/lib/screens/notice/notice_detail_screen.dart
+++ b/front/capstone_front/lib/screens/notice/notice_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:capstone_front/models/notice_model.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
 
 class NoticeDetailScreen extends StatefulWidget {
   NoticeModel notice;
@@ -36,7 +37,7 @@ class _NoticeDetailState extends State<NoticeDetailScreen> {
                     height: 16,
                   ),
                   Text(
-                    widget.notice.author!,
+                    '${widget.notice.author!} (${widget.notice.department!})',
                     style: const TextStyle(
                       color: Color(0xFF646464),
                       fontSize: 16,
@@ -45,7 +46,7 @@ class _NoticeDetailState extends State<NoticeDetailScreen> {
                   Row(
                     children: [
                       Text(
-                        widget.notice.department!,
+                        widget.notice.type!,
                         style: const TextStyle(
                           color: Color(0xFF8266DF),
                           fontSize: 16,
@@ -75,7 +76,8 @@ class _NoticeDetailState extends State<NoticeDetailScreen> {
                   const SizedBox(
                     height: 20,
                   ),
-                  Text(widget.notice.document!),
+                  // Text(widget.notice.document!),
+                  HtmlWidget(widget.notice.document!),
                   Container(
                     decoration: BoxDecoration(
                       border: Border.all(

--- a/front/capstone_front/lib/screens/notice/notice_detail_screen.dart
+++ b/front/capstone_front/lib/screens/notice/notice_detail_screen.dart
@@ -1,8 +1,9 @@
+import 'package:capstone_front/models/notice_model.dart';
 import 'package:flutter/material.dart';
 
 class NoticeDetailScreen extends StatefulWidget {
-  Map<String, dynamic> post;
-  NoticeDetailScreen(this.post, {super.key});
+  NoticeModel notice;
+  NoticeDetailScreen(this.notice, {super.key});
 
   @override
   State<NoticeDetailScreen> createState() => _NoticeDetailState();
@@ -16,7 +17,7 @@ class _NoticeDetailState extends State<NoticeDetailScreen> {
         backgroundColor: Theme.of(context).primaryColor,
         foregroundColor: Colors.white,
         title: Text(
-          widget.post['kind'],
+          widget.notice.department!,
           style: const TextStyle(
             fontWeight: FontWeight.bold,
           ),
@@ -24,75 +25,77 @@ class _NoticeDetailState extends State<NoticeDetailScreen> {
       ),
       body: Padding(
         padding: const EdgeInsets.all(20),
-        child: Column(
-          children: [
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(widget.post['title']),
-                const SizedBox(
-                  height: 16,
-                ),
-                const Text(
-                  "최지훈 (차세대통신사업단)",
-                  style: TextStyle(
-                    color: Color(0xFF646464),
-                    fontSize: 16,
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(widget.notice.title!),
+                  const SizedBox(
+                    height: 16,
                   ),
-                ),
-                Row(
-                  children: [
-                    Text(
-                      widget.post['kind'],
-                      style: const TextStyle(
-                        color: Color(0xFF8266DF),
-                        fontSize: 16,
+                  Text(
+                    widget.notice.author!,
+                    style: const TextStyle(
+                      color: Color(0xFF646464),
+                      fontSize: 16,
+                    ),
+                  ),
+                  Row(
+                    children: [
+                      Text(
+                        widget.notice.department!,
+                        style: const TextStyle(
+                          color: Color(0xFF8266DF),
+                          fontSize: 16,
+                        ),
                       ),
-                    ),
-                    const SizedBox(
-                      width: 10,
-                    ),
-                    Text(
-                      widget.post['date'],
-                      style: const TextStyle(
-                        color: Color(0xFF646464),
-                        fontSize: 16,
+                      const SizedBox(
+                        width: 10,
                       ),
+                      Text(
+                        widget.notice.createdDate!.substring(0, 10),
+                        style: const TextStyle(
+                          color: Color(0xFF646464),
+                          fontSize: 16,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(
+                    height: 20,
+                  ),
+                  Container(
+                    decoration: BoxDecoration(
+                      border: Border.all(
+                          width: 0.8, color: const Color(0xFFF3F3F3)),
                     ),
-                  ],
-                ),
-                const SizedBox(
-                  height: 20,
-                ),
-                Container(
-                  decoration: BoxDecoration(
-                    border:
-                        Border.all(width: 0.8, color: const Color(0xFFF3F3F3)),
                   ),
-                ),
-                const SizedBox(
-                  height: 20,
-                ),
-                const Text("본문 내용 입니다.\n본문 내용 입니다.\n본문 내용 입니다.\n본문 내용 입니다.\n"),
-                Container(
-                  decoration: BoxDecoration(
-                    border:
-                        Border.all(width: 0.8, color: const Color(0xFFF3F3F3)),
+                  const SizedBox(
+                    height: 20,
                   ),
-                ),
-                const SizedBox(
-                  height: 20,
-                ),
-                const Text(
-                  "첨부파일 1개",
-                  style: TextStyle(
-                    color: Color(0xFF646464),
-                    fontSize: 16,
+                  Text(widget.notice.document!),
+                  Container(
+                    decoration: BoxDecoration(
+                      border: Border.all(
+                          width: 0.8, color: const Color(0xFFF3F3F3)),
+                    ),
                   ),
-                ),
-              ],
-            )
-          ],
+                  const SizedBox(
+                    height: 20,
+                  ),
+                  const Text(
+                    "첨부파일 1개",
+                    style: TextStyle(
+                      color: Color(0xFF646464),
+                      fontSize: 16,
+                    ),
+                  ),
+                ],
+              )
+            ],
+          ),
         ),
       ),
     );

--- a/front/capstone_front/lib/screens/notice/notice_screen.dart
+++ b/front/capstone_front/lib/screens/notice/notice_screen.dart
@@ -144,10 +144,18 @@ class _NoticeScreenState extends State<NoticeScreen> {
               future: notices,
               builder: ((context, snapshot) {
                 if (snapshot.hasData) {
+                  var filteredNotices = snapshot.data!
+                      .where((notice) =>
+                          selectedItem == '전체공지' || notice.type == selectedItem)
+                      .toList();
+                  if (filteredNotices.isEmpty) {
+                    return const Center(child: Text('항목이 없습니다'));
+                  }
+
                   return ListView.separated(
-                    itemCount: snapshot.data!.length,
+                    itemCount: filteredNotices.length,
                     itemBuilder: (context, index) {
-                      var notice = snapshot.data![index];
+                      var notice = filteredNotices[index];
                       return ListTile(
                         title: Text(
                           notice.title!,
@@ -159,7 +167,7 @@ class _NoticeScreenState extends State<NoticeScreen> {
                         subtitle: Row(
                           children: [
                             Text(
-                              notice.department!,
+                              notice.type!,
                               style: const TextStyle(
                                 fontSize: 16,
                                 color: Color(0xFF8266DF),

--- a/front/capstone_front/lib/screens/notice/notice_screen.dart
+++ b/front/capstone_front/lib/screens/notice/notice_screen.dart
@@ -1,6 +1,9 @@
+import 'package:capstone_front/models/notice_model.dart';
 import 'package:capstone_front/screens/notice/test_notice_data.dart';
 import 'package:capstone_front/screens/notice/notice_detail_screen.dart';
+import 'package:capstone_front/services/notice_service.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 class NoticeScreen extends StatefulWidget {
   const NoticeScreen({super.key});
@@ -13,6 +16,8 @@ class _NoticeScreenState extends State<NoticeScreen> {
   List<String> items = ['전체공지', '학사공지', '장학공지'];
   String selectedItem = '전체공지';
   final _controller = TextEditingController();
+
+  Future<List<NoticeModel>> notices = NoticeService.getNotices();
 
   @override
   Widget build(BuildContext context) {
@@ -135,54 +140,67 @@ class _NoticeScreenState extends State<NoticeScreen> {
             height: 20,
           ),
           Expanded(
-            child: ListView.separated(
-              itemCount: posts.length,
-              itemBuilder: (context, index) {
-                return ListTile(
-                  title: Text(
-                    posts[index]['title'],
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      fontSize: 18,
+            child: FutureBuilder(
+              future: notices,
+              builder: ((context, snapshot) {
+                if (snapshot.hasData) {
+                  return ListView.separated(
+                    itemCount: snapshot.data!.length,
+                    itemBuilder: (context, index) {
+                      var notice = snapshot.data![index];
+                      return ListTile(
+                        title: Text(
+                          notice.title!,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            fontSize: 18,
+                          ),
+                        ),
+                        subtitle: Row(
+                          children: [
+                            Text(
+                              notice.department!,
+                              style: const TextStyle(
+                                fontSize: 16,
+                                color: Color(0xFF8266DF),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            const SizedBox(
+                              width: 10,
+                            ),
+                            Expanded(
+                              child: Text(
+                                notice.createdDate!.substring(0, 10),
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  color: Color(0xFFc8c8c8),
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => NoticeDetailScreen(notice),
+                            ),
+                          );
+                        },
+                      );
+                    },
+                    separatorBuilder: (context, index) => const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 18),
+                      child: Divider(
+                        color: Color(0xFFc8c8c8),
+                      ),
                     ),
-                  ),
-                  subtitle: Row(
-                    children: [
-                      Text(
-                        posts[index]['kind'],
-                        style: const TextStyle(
-                          fontSize: 16,
-                          color: Color(0xFF8266DF),
-                        ),
-                      ),
-                      const SizedBox(
-                        width: 10,
-                      ),
-                      Text(
-                        posts[index]['date'],
-                        style: const TextStyle(
-                          fontSize: 16,
-                          color: Color(0xFFc8c8c8),
-                        ),
-                      ),
-                    ],
-                  ),
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => NoticeDetailScreen(posts[index]),
-                      ),
-                    );
-                  },
-                );
-              },
-              separatorBuilder: (context, index) => const Padding(
-                padding: EdgeInsets.symmetric(horizontal: 18),
-                child: Divider(
-                  color: Color(0xFFc8c8c8),
-                ),
-              ),
+                  );
+                }
+                return const Center(child: CircularProgressIndicator());
+              }),
             ),
           )
         ],

--- a/front/capstone_front/lib/services/notice_service.dart
+++ b/front/capstone_front/lib/services/notice_service.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+
+import 'package:capstone_front/models/notice_model.dart';
+import 'package:http/http.dart' as http;
+
+class NoticeService {
+  static const String baseUrl =
+      'http://ec2-13-125-0-173.ap-northeast-2.compute.amazonaws.com:8080/api';
+
+  static Future<List<NoticeModel>> getNotices() async {
+    List<NoticeModel> noticeInstances = [];
+    final url = Uri.parse('$baseUrl/announcement/');
+    final response = await http.get(url);
+
+    if (response.statusCode == 200) {
+      final String decodedBody = utf8.decode(response.bodyBytes);
+      final List<dynamic> notices = jsonDecode(decodedBody);
+
+      for (var notice in notices) {
+        noticeInstances.add(NoticeModel.fromJson(notice));
+      }
+      return noticeInstances;
+    } else {
+      print('Request failed with status: ${response.statusCode}.');
+      throw Exception('Failed to load notices');
+    }
+  }
+}

--- a/front/capstone_front/lib/services/notice_service.dart
+++ b/front/capstone_front/lib/services/notice_service.dart
@@ -1,11 +1,11 @@
 import 'dart:convert';
 
 import 'package:capstone_front/models/notice_model.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
 
 class NoticeService {
-  static const String baseUrl =
-      'http://ec2-13-125-0-173.ap-northeast-2.compute.amazonaws.com:8080/api';
+  static String baseUrl = dotenv.get('BASE_URL');
 
   static Future<List<NoticeModel>> getNotices() async {
     List<NoticeModel> noticeInstances = [];

--- a/front/capstone_front/pubspec.yaml
+++ b/front/capstone_front/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   audio_session: ^0.1.18
   permission_handler: ^11.3.1
   flutter_screenutil: ^5.9.0
+  flutter_widget_from_html: ^0.14.11
 
 dev_dependencies:
   flutter_test:

--- a/front/capstone_front/pubspec.yaml
+++ b/front/capstone_front/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   permission_handler: ^11.3.1
   flutter_screenutil: ^5.9.0
   flutter_widget_from_html: ^0.14.11
+  flutter_dotenv: ^5.1.0
 
 dev_dependencies:
   flutter_test:
@@ -74,6 +75,8 @@ flutter:
     - assets/translations/
     - assets/images/carrot_profile.png
     - assets/images/koomin.png
+
+    - .env
 
   fonts:
     - family: pretendard


### PR DESCRIPTION
## Overview

- notice service 클래스 생성 및 모델 생성
- notice api data fetch
- flutter_widget_from_html 패키지 설치 및 공지 내용 htmlWidget으로 show
- 공지사항 필터 적용

### Related Issue

Issue Number : #56 

## Task Details

- 공지사항을 htmlWidget으로 불러옴
- 단, 내용이 이미지만 있는 경우에, 그 이미지의 src가 내부주소(상대주소)인 경우 아무것도 리턴하지 않음
- CSS의 한계가 있어 서식이 완벽하지 않은 경우가 있음

## Screenshots (Optional)
<img width="250" alt="스크린샷 2024-04-15 오후 7 35 41" src="https://github.com/kookmin-sw/capstone-2024-30/assets/52407470/21ed2e99-7388-42c4-b5d6-73ca796af963">
<img width="250" alt="스크린샷 2024-04-15 오후 7 35 51" src="https://github.com/kookmin-sw/capstone-2024-30/assets/52407470/917d29ea-0cf8-4e0a-8116-0e9901ec050f">
<img width="250" alt="스크린샷 2024-04-15 오후 7 36 14" src="https://github.com/kookmin-sw/capstone-2024-30/assets/52407470/89ab04be-2718-431c-817e-26cf15390bf7">



## Test Scope & Checklist (Optional)

> Please explain test scope, task, plan, method
- [x] 현재 존재하지 않는 공지사항 필터를 선택했을 때, 화면이 멈추지 않고 정상적으로 항목이 없다고 표시되는지
- [x] 화면이 overflow되는 구간이 없는지