### PR TITLE
fix: #77-메인에서 학식정보, 공지사항 카드 클릭하면 해당 페이지로 이동하도록 수정

### DIFF
--- a/front/capstone_front/lib/screens/home/home_screen.dart
+++ b/front/capstone_front/lib/screens/home/home_screen.dart
@@ -1,3 +1,5 @@
+import 'package:capstone_front/screens/cafeteriaMenu/cafeteriaMenuScreen.dart';
+import 'package:capstone_front/screens/notice/notice_screen.dart';
 import 'package:capstone_front/utils/bubble_painter1.dart';
 import 'package:capstone_front/utils/white_box.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -103,8 +105,17 @@ class _HomeScreenState extends State<HomeScreen> {
                                               fontSize: 24,
                                               fontWeight: FontWeight.w700,
                                             )),
-                                        const Icon(
-                                          Icons.add,
+                                        IconButton(
+                                          icon: const Icon(Icons.add),
+                                          onPressed: () {
+                                            Navigator.push(
+                                              context,
+                                              MaterialPageRoute(
+                                                builder: (context) =>
+                                                    const NoticeScreen(),
+                                              ),
+                                            );
+                                          },
                                         ),
                                       ],
                                     ),
@@ -167,8 +178,17 @@ class _HomeScreenState extends State<HomeScreen> {
                                               fontSize: 24,
                                               fontWeight: FontWeight.w700,
                                             )),
-                                        const Icon(
-                                          Icons.add,
+                                        IconButton(
+                                          icon: const Icon(Icons.add),
+                                          onPressed: () {
+                                            Navigator.push(
+                                              context,
+                                              MaterialPageRoute(
+                                                builder: (context) =>
+                                                    const CafeteriaMenuScreen(),
+                                              ),
+                                            );
+                                          },
                                         ),
                                       ],
                                     ),


### PR DESCRIPTION
## Overview

- [FE] 메인화면에서 학식정보, 공지사항 plus 버튼 클릭했을 때 이동하도록 수정

### Related Issue

Issue Number : #77 

## Task Details

- 학식정보 디테일페이지로 이동하기 위해 add 버튼 클릭했을 때 디테일 페이지로 이동하게 변경
- 하는김에 공지사항도
