### PR TITLE
refactor: #146-answerCount 계산을 위한 SQL문 수정

### DIFF
--- a/back/src/main/java/com/example/capstone/domain/qna/dto/QuestionListResponse.java
+++ b/back/src/main/java/com/example/capstone/domain/qna/dto/QuestionListResponse.java
@@ -12,6 +12,7 @@ public record QuestionListResponse (
         String context,
         String tag,
         String country,
+        Long answerCount,
         LocalDateTime createdDate
 ) {
 }

--- a/back/src/main/java/com/example/capstone/domain/qna/dto/QuestionSliceResponse.java
+++ b/back/src/main/java/com/example/capstone/domain/qna/dto/QuestionSliceResponse.java
@@ -6,7 +6,6 @@ import java.util.Map;
 public record QuestionSliceResponse(
         Long lastCursorId,
         Boolean hasNext,
-        List<QuestionListResponse> questionList,
-        Map<Long, Long> answerCountList
+        List<QuestionListResponse> questionList
 ) {
 }


### PR DESCRIPTION
## Overview

answerCount 계산을 위한 SQL 쿼리를 수정했습니다.

### Related Issue

Issue Number : #146 

## Task Details

기존에 Map 자료형으로 별첨하던 answerCount를 각 question에서 해당 ID를 가진 answer count를 계산하는 것으로 구현했습니다.
N+1문제 또한 해결하였습니다.

## Test Scope & Checklist (Optional)

- [ ] api/question/list Endpoint에서 answerCount 포함된 Response가 반환되는가

## Review Requirements