### PR TITLE
Feature/fe/#139 cafeteria api

### DIFF
--- a/front/capstone_front/assets/translations/ko-KR.json
+++ b/front/capstone_front/assets/translations/ko-KR.json
@@ -48,6 +48,9 @@
     "language_setting": "언어 설정",
     "logout": "로그아웃"
   },
+  "cafeteria": {
+    "no_data": "미운영중입니다"
+  },
   "speech": {
     "speech_practice": "발음 연습",
     "example_sentence": "예문",

--- a/front/capstone_front/lib/main.dart
+++ b/front/capstone_front/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:capstone_front/firebase_options.dart';
+import 'package:capstone_front/models/cafeteria_menu_model.dart';
 import 'package:capstone_front/models/notice_model.dart';
 import 'package:capstone_front/models/qna_post_model.dart';
 import 'package:capstone_front/provider/qna_provider.dart';
@@ -29,6 +30,7 @@ import 'package:capstone_front/screens/speech_practice/speech_practice_screen.da
 import 'package:capstone_front/screens/speech_practice/speech_screen.dart';
 import 'package:capstone_front/screens/speech_practice/speech_example_sentences/speech_select_sentence_screen.dart';
 import 'package:capstone_front/screens/speech_practice/utils/recorder_screen.dart';
+import 'package:capstone_front/services/cafeteria_menu_service.dart';
 import 'package:capstone_front/utils/page_animation.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -47,6 +49,9 @@ List<String> languageSetting = ['ko', 'KR'];
 
 // 로그인 되어있었는지 여부
 bool _isLogin = false;
+
+// 학식 메뉴
+late CafeteriaMenuModel menus;
 
 // 언어를 설정해주고 로그인 정보를 불러오는 함수
 Future<void> setSetting() async {
@@ -69,12 +74,18 @@ void initializeFirebase() async {
   );
 }
 
+Future<void> getMenus() async {
+  menus =
+      await getCafeteriaMenu(DateTime.now().toString().substring(0, 10), 'KO');
+}
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   initializeFirebase();
   await setSetting();
   await EasyLocalization.ensureInitialized();
   await dotenv.load(fileName: ".env");
+  await getMenus();
 
   runApp(
     EasyLocalization(

--- a/front/capstone_front/lib/models/cafeteria_menu_model.dart
+++ b/front/capstone_front/lib/models/cafeteria_menu_model.dart
@@ -1,0 +1,80 @@
+class CafeteriaMenuModel {
+  List<String> cafeteria = [
+    "한울식당(법학관 지하1층)",
+    "학생식당(복지관 1층)",
+    "교직원식당(복지관 1층)",
+    "청향 한식당(법학관 5층)",
+    "청향 양식당(법학관 5층)",
+    "생활관식당 일반식(생활관 A동 1층)",
+    "생활관식당 정기식(생활관 A동 1층)",
+  ];
+  List<List<List<String>>> cafeteriaMenus = [];
+
+  void addFunc(
+      var data, List<List<String>> targetList, String type, String addName) {
+    if (data != null && data[type] != null) {
+      targetList.add([addName, data[type]["메뉴"], data[type]["가격"]]);
+    }
+  }
+
+  void addData(int cafeteriaIndex, var data) {
+    List<List<String>> tmpList = [];
+    if (cafeteriaIndex == 0) {
+      addFunc(data, tmpList, "1코너<br>SNACK1", "1코너 SNACK1");
+      addFunc(data, tmpList, "1코너<br>SNACK2", "1코너 SNACK2");
+      addFunc(data, tmpList, "2코너<BR>NOODLE", "2코너 NOODLE");
+      addFunc(data, tmpList, "3코너<br>CUTLET", "3코너 CUTLET");
+      addFunc(data, tmpList, "4코너<br>ROCE.Oven", "4코너 RICE.Oven");
+      addFunc(data, tmpList, "5코너<br>GUKBAP.Chef", "5코너 GUKBAP.Chef");
+    } else if (cafeteriaIndex == 1) {
+      addFunc(data, tmpList, "착한아침", "착한아침");
+      addFunc(data, tmpList, "천원의 아침밥", "천원의 아침밥");
+      addFunc(data, tmpList, "가마<br>중식", "가마 중식");
+      addFunc(data, tmpList, "데일리밥<br>중식", "데일리밥 중식");
+      addFunc(data, tmpList, "채식<br>중식", "채식 중식");
+      addFunc(data, tmpList, "인터쉐프<br>중식", "인터쉐프 중식");
+      addFunc(data, tmpList, "누들송<br>중식", "누들송 중식");
+      addFunc(data, tmpList, "석식Ⅰ", "석식Ⅰ");
+      addFunc(data, tmpList, "석식Ⅱ", "석식Ⅱ");
+    } else if (cafeteriaIndex == 2) {
+      addFunc(data, tmpList, "키친1", "키친1");
+      addFunc(data, tmpList, "키친2", "키친2");
+      addFunc(data, tmpList, "오늘의<br>샐러드", "오늘의 샐러드");
+      addFunc(data, tmpList, "석식", "석식");
+    } else if (cafeteriaIndex == 3) {
+      addFunc(data, tmpList, "메뉴1", "메뉴1");
+      addFunc(data, tmpList, "메뉴2", "메뉴2");
+      addFunc(data, tmpList, "메뉴3", "메뉴3");
+      addFunc(data, tmpList, "메뉴4", "메뉴4");
+    } else if (cafeteriaIndex == 4) {
+      addFunc(data, tmpList, "파스타", "PASTA");
+      addFunc(data, tmpList, "리조또", "RISOTTO");
+      addFunc(data, tmpList, "STEAK", "STEAK");
+    } else if (cafeteriaIndex == 5) {
+      addFunc(data, tmpList, "중식", "중식");
+    } else if (cafeteriaIndex == 6) {
+      if (data != null && data["석식"] != null) {
+        tmpList.add(["생활관식당 정기식", data["석식"]["메뉴"], "정기식 신청자 한정"]);
+      }
+    }
+    cafeteriaMenus.add(tmpList);
+  }
+
+  CafeteriaMenuModel.fromJson(List<dynamic> json, String date) {
+    for (int i = 0; i < cafeteria.length; i++) {
+      bool dataAdded = false;
+      for (int j = 0; j < json.length; j++) {
+        if (json[j][cafeteria[i]] != null) {
+          addData(i, json[j][cafeteria[i]][date]);
+          dataAdded = true;
+          break;
+        }
+      }
+      if (!dataAdded) {
+        cafeteriaMenus.add([]);
+      }
+    }
+    print(cafeteriaMenus.length);
+    print(cafeteriaMenus[6]);
+  }
+}

--- a/front/capstone_front/lib/screens/cafeteriaMenu/cafeteriaMenuScreen.dart
+++ b/front/capstone_front/lib/screens/cafeteriaMenu/cafeteriaMenuScreen.dart
@@ -1,5 +1,10 @@
+import 'package:capstone_front/main.dart';
+import 'package:capstone_front/models/cafeteria_menu_model.dart';
 import 'package:capstone_front/screens/cafeteriaMenu/dateChanger.dart';
 import 'package:capstone_front/screens/cafeteriaMenu/menuCard.dart';
+import 'package:capstone_front/screens/main_screen.dart';
+import 'package:capstone_front/services/cafeteria_menu_service.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -19,21 +24,23 @@ class _CafeteriaMenuScreenState extends State<CafeteriaMenuScreen>
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        iconTheme: const IconThemeData(
-          color: Colors.white,
-        ),
-        backgroundColor: Theme.of(context).primaryColor,
-        title: const Text(
-          '학식정보',
-          style: TextStyle(
-            color: Colors.white,
-            fontWeight: FontWeight.bold,
-          ),
+        scrolledUnderElevation: 0,
+        title: Text(
+          tr('mainScreen.cafeteria'),
+          style: const TextStyle(),
         ),
       ),
       body: Column(
         children: [
-          const DateChanger(),
+          // const DateChanger(),
+          Text(
+            DateTime.now().toString().substring(0, 11),
+            style: const TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.w500,
+            ),
+            textAlign: TextAlign.center,
+          ),
           TabBar(
             tabAlignment: TabAlignment.start,
             isScrollable: true,
@@ -66,37 +73,18 @@ class _CafeteriaMenuScreenState extends State<CafeteriaMenuScreen>
             child: TabBarView(
               controller: tabController,
               children: <Widget>[
-                Expanded(
-                  child: Container(
-                      color: const Color(0xFFF8F8F8),
-                      child: const Column(
-                        children: [
-                          MenuCard(
-                            section: "인터쉐프 중식",
-                            menu: "고깃집 볶음밥",
-                            price: "5,000",
-                          ),
-                        ],
-                      )),
-                ),
-                const Center(
-                  child: Text("학생식당"),
-                ),
-                const Center(
-                  child: Text("교직원식당"),
-                ),
-                const Center(
-                  child: Text("청향 한식당"),
-                ),
-                const Center(
-                  child: Text("청향 양식당"),
-                ),
-                const Center(
-                  child: Text("생활관식당 일반식"),
-                ),
-                const Center(
-                  child: Text("생활관식당 정기식"),
-                ),
+                for (int i = 0; i <= 6; i++)
+                  SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        const SizedBox(height: 15),
+                        if (menus.cafeteriaMenus[i].isEmpty)
+                          Center(child: Text(tr('cafeteria.no_data'))),
+                        for (var data in menus.cafeteriaMenus[i])
+                          MenuCard(data: data),
+                      ],
+                    ),
+                  ),
               ],
             ),
           ),

--- a/front/capstone_front/lib/screens/cafeteriaMenu/menuCard.dart
+++ b/front/capstone_front/lib/screens/cafeteriaMenu/menuCard.dart
@@ -1,26 +1,54 @@
 import 'package:flutter/material.dart';
 
 class MenuCard extends StatelessWidget {
-  final String section, menu, price;
+  final List<String> data;
 
   const MenuCard({
     super.key,
-    required this.section,
-    required this.menu,
-    required this.price,
+    required this.data,
   });
 
   @override
   Widget build(BuildContext context) {
+    String section = data[0];
+    String menu = data[1];
+    String price = data[2];
+
+    // menu
+    menu = menu.replaceAll('\r\n', ' ');
+    // ※가 2번 나오면 줄바꿈
+    int tmp1 = 0;
+    // []가 2번 이상 나오면 줄바꿈
+    int tmp2 = 0;
+    for (int i = 0; i < menu.length; i++) {
+      if (menu[i] == '※') {
+        tmp1 += 1;
+        if (tmp1 == 1) {
+          menu = '${menu.substring(0, i + 1)} ${menu.substring(i + 1)}';
+        }
+      } else if (menu[i] == '[') {
+        tmp2 += 1;
+        if (tmp2 >= 2) {
+          menu = '${menu.substring(0, i)}\n${menu.substring(i)}';
+          i += 2;
+        }
+      }
+      if (tmp1 == 2) {
+        tmp1 = 0;
+        menu = '${menu.substring(0, i + 1)}\n${menu.substring(i + 2)}';
+      }
+    }
+
     return Padding(
-      padding: const EdgeInsets.all(20),
+      padding: const EdgeInsets.only(left: 15, right: 15, bottom: 15),
       child: Container(
+        width: double.infinity,
         decoration: BoxDecoration(
           color: Colors.white,
           borderRadius: BorderRadius.circular(12.0),
           boxShadow: [
             BoxShadow(
-              color: Colors.grey.withOpacity(0.2),
+              color: Colors.black.withOpacity(0.15),
               spreadRadius: 2,
               blurRadius: 5,
               offset: const Offset(0, 3),
@@ -46,20 +74,19 @@ class MenuCard extends StatelessWidget {
                   fontSize: 16,
                 ),
               ),
-              const SizedBox(height: 8),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(
-                    price,
-                    style: const TextStyle(
-                      fontSize: 14,
-                      color: Colors.grey,
+              if (price != "0")
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      '\u20A9$price',
+                      style: const TextStyle(
+                        fontSize: 16,
+                      ),
                     ),
-                  ),
-                  // Add any additional widgets here
-                ],
-              ),
+                    // Add any additional widgets here
+                  ],
+                ),
             ],
           ),
         ),

--- a/front/capstone_front/lib/services/cafeteria_menu_service.dart
+++ b/front/capstone_front/lib/services/cafeteria_menu_service.dart
@@ -1,0 +1,183 @@
+import 'dart:convert';
+
+import 'package:capstone_front/models/api_fail_response.dart';
+import 'package:capstone_front/models/api_success_response.dart';
+import 'package:capstone_front/models/cafeteria_menu_model.dart';
+import 'package:capstone_front/models/notice_model.dart';
+import 'package:capstone_front/models/notice_response.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+
+Future<CafeteriaMenuModel> getCafeteriaMenu(
+    String date, String language) async {
+  final String baseUrl = dotenv.get('BASE_URL');
+  final url = Uri.parse('$baseUrl/menu/daily?date=$date&language=$language');
+  final response = await http.get(url);
+
+  final Map<String, dynamic> json = jsonDecode(utf8.decode(response.bodyBytes));
+
+  final Map<String, dynamic> jsonExample = {
+    "success": true,
+    "message": "Successfully load menus",
+    "response": [
+      {
+        "한울식당(법학관 지하1층)": {
+          "2024-05-04": {
+            "5코너<br>GUKBAP.Chef": {
+              "가격": "0",
+              "메뉴": "[중식]\r\n부대찌개\r\n￦5000\r\n[석식]\r\n얼큰국밥\r\n￦6000"
+            },
+            "3코너<br>CUTLET": {"가격": "5000", "메뉴": "[중식]\r\n치킨까스"},
+            "1코너<br>SNACK1": {
+              "가격": "0",
+              "메뉴":
+                  "※학기중\r\n운영시간\r\n안내\r\n\r\n평일\r\n11시~18시30분\r\n※ 토/일요일 및 공휴일\r\n휴점"
+            },
+            "2코너<BR>NOODLE": {"가격": "3900", "메뉴": "[중식]\r\n바지락칼국수\r\n&손만두3"},
+            "4코너<br>RICE.Oven": {
+              "가격": "0",
+              "메뉴": "[중식]\r\n제육파채비빔밥\r\n￦4300\r\n[중석식]\r\n소고기덮밥\r\n￦4900"
+            }
+          }
+        }
+      },
+      {
+        "학생식당(복지관 1층)": {
+          "2024-05-04": {
+            "착한아침": {
+              "가격": "3500",
+              "메뉴": "북어미역국\r\n기장밥/계란후라이\r\n돼지고기장조림\r\n고들빼기무침\r\n"
+            },
+            "인터쉐프<br>중식": {
+              "가격": "5500",
+              "메뉴":
+                  "[금주의 추천메뉴]\r\n트윈까스SET\r\n(등심돈까스&생선까스)\r\n크림스프/후리가케밥小\r\n그린샐러드/쥬시쿨\r\n"
+            },
+            "데일리밥<br>중식": {"가격": "3700", "메뉴": "미트볼갈릭볶음밥\r\n\r\n그린샐러드\r\n"},
+            "차이웨이<br>상시": {
+              "가격": "0",
+              "메뉴":
+                  "찹쌀탕수육4000\r\n직화간짜장4700\r\n직화짬뽕 5500\r\n짬짜면 6700\r\n공기밥 1000\r\n"
+            },
+            "채식<br>중식": {
+              "가격": "0",
+              "메뉴": "※채식(데일리밥)코너 운영시간\r\n(매주 수요일) 11:00 ~ 선착순 100개)"
+            },
+            "누들송<br>중식": {"가격": "3900", "메뉴": "미소라멘\r\n\r\n쥬시쿨\r\n"},
+            "천원의 아침밥": {
+              "가격": "1000",
+              "메뉴": "황태미역국\r\n기장밥/계란후라이\r\n돼지고기장조림\r\n고들빼기무침\r\n국민두유\r\n"
+            },
+            "석식Ⅰ": {
+              "가격": "5000",
+              "메뉴": "뚝)들깨수제비\r\n쌀밥 小\r\n야채튀김\r\n무말랭이무침\r\n"
+            },
+            "가마<br>중식": {
+              "가격": "5000",
+              "메뉴": "뚝)누룽지찜닭\r\n쌀밥\r\n단호박전\r\n오이깍뚝무침\r\n"
+            },
+            "석식Ⅱ": {"가격": "4800", "메뉴": "우삼겹마파두부덮밥\r\n\r\n야채튀김\r\n무말랭이무침\r\n"}
+          }
+        }
+      },
+      {
+        "교직원식당(복지관 1층)": {
+          "2024-05-04": {
+            "키친1": {
+              "가격": "7700",
+              "메뉴":
+                  "뚝)짬뽕순두부찌개*쫄면사리\r\n차조밥\r\n떡갈비피망조림\r\n감자채볶음\r\n브로콜리숙회\r\n저염김치\r\n"
+            },
+            "키친2": {
+              "가격": "7700",
+              "메뉴": "미나리삼겹나물비빔밥\r\n얼갈이국\r\n설탕핫도그\r\n흑임자연근무침\r\n저염김치\r\n"
+            },
+            "오늘의<br>샐러드": {
+              "가격": "0",
+              "메뉴": "양상추샐러드&삼색야채샐러드\r\n샐러드토핑2종&드레싱2종\r\n과일푸딩\r\n현미밥&숭늉\r\n"
+            },
+            "석식": {
+              "가격": "7700",
+              "메뉴":
+                  "뚝)비벼먹는 고추장찌개\r\n쌀밥\r\n순살햄구이\r\n파래자반볶음\r\n도토리묵무침\r\n깍두기\r\n양상추샐러드&삼색야채샐러드\r\n식혜\r\n"
+            }
+          }
+        }
+      },
+      {
+        "청향 한식당(법학관 5층)": {
+          "2024-05-04": {
+            "메뉴1": {"가격": "10000", "메뉴": "차돌육개장"},
+            "메뉴3": {"가격": "16000", "메뉴": "들기름메밀막국수와 수육정식"},
+            "메뉴2": {"가격": "14000", "메뉴": "숯불주꾸미비빔밥&미니된장찌개정식"},
+            "메뉴4": {"가격": "17000", "메뉴": "철판 훈제오리구이와 단호박오곡영양솥밥정식"}
+          }
+        }
+      },
+      {
+        "청향 양식당(법학관 5층)": {
+          "2024-05-04": {
+            "STEAK": {
+              "가격": "0",
+              "메뉴": "채끝스테이크\r\n37,000원\r\n안심스테이크\r\n43,000원"
+            },
+            "파스타": {
+              "가격": "0",
+              "메뉴":
+                  "알리오올리오 17,000원\r\n포모도로\r\n19,000원\r\n감바스알아히오\r\n19,000원\r\n까르보나라\r\n20,000원\r\n해산물토마토파스타 23,000원\r\n(NEW) 통베이컨로제파스타\r\n25,000원\r\nLA갈비오일파스타\r\n29,000원"
+            },
+            "리조또": {
+              "가격": "0",
+              "메뉴": "트러플베이컨풍기리조또\r\n20,000원\r\n아보카도부라타리조또\r\n27,000원"
+            }
+          }
+        }
+      },
+      {
+        "생활관식당 일반식(생활관 A동 1층)": {
+          "2024-05-04": {
+            "중식": {
+              "가격": "7700",
+              "메뉴":
+                  "깻잎간장제육\r\n\r\n수수밥\r\n두부김칫국\r\n꼬시래기곤약무침\r\n멸치볶음\r\n유자무생채\r\n열무김치\r\n매실주스\r\n\"♥비빔 DIY코너♥\r\n(김가루,고추장,참기름)\"\r\n"
+            }
+          }
+        }
+      },
+      {
+        "생활관식당 정기식(생활관 A동 1층)": {
+          "2024-05-04": {
+            "석식": {
+              "가격": "0",
+              "메뉴":
+                  "하이라이스정식\r\n\r\n미소시루\r\n함박까스&소스2종\r\n양배추샐러드*드레싱\r\n깍두기\r\n요구르트\r\n"
+            }
+          }
+        }
+      },
+      {
+        "K-Bob<sup>+</sup>": {
+          "2024-05-04": {
+            "사전주문안내": {"가격": "0", "메뉴": "*회의 및 행사용 도시락의 경우 3일전 주문 필수"},
+            "오늘의도시락": {"가격": "0", "메뉴": "※운영시간\r\n11시~17시\r\n\r\n※주말 및 공휴일 휴점"},
+            "간편도시락": {
+              "가격": "0",
+              "메뉴":
+                  "통스팸김치덮밥\r\n￦6500\r\n돈가스마요덮밥\r\n￦7500\r\n핵불닭덮밥\r\n￦7500\r\n참치비빔밥\r\n￦6500\r\n삼겹살비빔밥\r\n￦7900\r\n육회비빔밥\r\n￦7700\r\n(특)육회비빔밥\r\n￦10000\r\n치즈부대찌개\r\n￦7900\r\n치즈스팸부대찌개\r\n￦9000\r\n대패삼겹도시락\r\n￦10000\r\n항정살도시락\r\n￦11500\r\n가브리살도시락\r\n￦11500"
+            }
+          }
+        }
+      }
+    ]
+  };
+  // return CafeteriaMenuModel.fromJson(jsonExample['response'], date);
+  if (response.statusCode == 200) {
+    return CafeteriaMenuModel.fromJson(json['response'], date);
+    // return CafeteriaMenuModel.fromJson(jsonExample['response'], date);
+  } else {
+    var apiFailResponse = ApiFailResponse.fromJson(json);
+    print('Request failed with status: ${response.statusCode}.');
+    print(apiFailResponse.message);
+    throw Exception('Failed to load notices');
+  }
+}

--- a/front/capstone_front/lib/services/cafeteria_menu_service.dart
+++ b/front/capstone_front/lib/services/cafeteria_menu_service.dart
@@ -172,8 +172,8 @@ Future<CafeteriaMenuModel> getCafeteriaMenu(
   };
 
   if (response.statusCode == 200) {
-    // return CafeteriaMenuModel.fromJson(json['response'], date);
-    return CafeteriaMenuModel.fromJson(jsonExample['response'], date);
+    return CafeteriaMenuModel.fromJson(json['response'], date);
+    // return CafeteriaMenuModel.fromJson(jsonExample['response'], date);
   } else {
     var apiFailResponse = ApiFailResponse.fromJson(json);
     print('Request failed with status: ${response.statusCode}.');


### PR DESCRIPTION
## Overview
식당 메뉴 받아오고 보여주기

### Related Issue
Issue Number : #139 

## Task Details
처음에 앱을 실행할 때 (main.dart) menus에 오늘의 학식 정보를 저장합니다.
이후 menus를 활용하여 학식 정보를 보여줍니다.
특이사항으로 현재 날짜 크롤링이 안되어있어 학식정보가 안보이는데
cafeteria_menu_service.dart에서 175번 줄을 주석처리하고
176번 줄의 주석을 풀어 예제 데이터를 통해 확인할 수 있습니다.


## Screenshots (Optional)
|![Screenshot_1714830862](https://github.com/kookmin-sw/capstone-2024-30/assets/55120784/f04532b1-b608-4bea-987a-1dcabdbf132d)|![Screenshot_1714830865](https://github.com/kookmin-sw/capstone-2024-30/assets/55120784/4c5511bb-b754-4012-9915-ddaddcfe5b91)|
|-|-|


## Test Scope & Checklist (Optional)

- [x] 홈 화면에서 한울식당의 메뉴가 나온다
- [x] + 버튼을 눌러 식당 별 학식정보를 확인할 수 있다.
- [x] cafeteria_menu_service.dart의 주석을 수정하여 예제 데이터에 대해서도 확인해본다

## Review Requirements
