### PR TITLE
refactor: #151-DTO 기반 Fetch Join 문제 해결

### DIFF
--- a/back/src/main/java/com/example/capstone/domain/qna/repository/FAQImageRepositoryImpl.java
+++ b/back/src/main/java/com/example/capstone/domain/qna/repository/FAQImageRepositoryImpl.java
@@ -20,8 +20,7 @@ public class FAQImageRepositoryImpl implements FAQImageCustomRepository{
         List<String> urlList = jpaQueryFactory
                 .select(faqImage.url)
                 .from(faqImage)
-                .leftJoin(faqImage.faqId, faq)
-                .fetchJoin()
+                .innerJoin(faqImage.faqId, faq)
                 .where(faqImage.faqId.id.eq(faqId))
                 .distinct()
                 .fetch();

--- a/back/src/main/java/com/example/capstone/domain/qna/repository/QuestionImageRepositoryImpl.java
+++ b/back/src/main/java/com/example/capstone/domain/qna/repository/QuestionImageRepositoryImpl.java
@@ -20,8 +20,7 @@ public class QuestionImageRepositoryImpl implements QuestionImageCustomRepositor
         List<String> urlList = jpaQueryFactory
                 .select(questionImage.url)
                 .from(questionImage)
-                .leftJoin(questionImage.questionId, question)
-                .fetchJoin()
+                .innerJoin(questionImage.questionId, question)
                 .where(questionImage.questionId.id.eq(questionId))
                 .distinct()
                 .fetch();


### PR DESCRIPTION
## Overview

DTO 기반 Fetch Join 문제를 해결하였다.

### Related Issue

Issue Number : #151 

## Task Details

일반적인 Entity 기반 SQL 검색과 달리, Projection을 사용한 DTO 기반 검색에서 Fetch Join을 실행하게 되면 문제가 발생한다.
Fetch Join 자체가 Entity를 기반으로 해당 일대다와 같이 다른 Entity를 참조해야 할 경우 EntityGraph를 참고하기 위함인데 해당 경우에는 DTO를 Projection을 사용하여 조회를 하게되어 당연히 작동하지 않게 된다... 로컬 테스트 당시에는 이미지 관련 검색을 추가하지 않아서 빠뜨린 것 같다. 
해결방법은 2가지로 Fetch Join에서 Inner Join으로 바꾸는 방법과 Entity 기반 검색으로 하고 DTO로 추후에 mapping 하는 방법이 있는데 Inner Join 방법은 시도해본적이 없어서 이번 기회에 해보았다. SQL문에서 Id 비교만을 위해서 Question Entity를 참조하는 것이기 때문에 Inner Join으로 하여도 문제가 없었다. 혹시 모를 N+1 방지를 위한 Distinct 까지 처리해주었다.

## Test Scope & Checklist (Optional)

- [ ] Question 조회시 이미지 리스트가 정상 반환되는가
- [ ] FAQ 조회시 이미지 리스트가 정상 반환되는가

## Review Requirements