### PR TITLE
Feature/be/#159 API Rate Limiter 적용

### DIFF
--- a/back-gateway/build.gradle
+++ b/back-gateway/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+    implementation 'io.lettuce.core:lettuce-core:6.3.2'
 }
 
 dependencyManagement {

--- a/back-gateway/build.gradle
+++ b/back-gateway/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 }
 
 dependencyManagement {

--- a/back-gateway/build.gradle
+++ b/back-gateway/build.gradle
@@ -26,7 +26,6 @@ ext {
 }
 
 dependencies {
-    implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -36,7 +35,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
-    implementation 'io.lettuce.core:lettuce-core:6.3.2'
+    implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 }
 
 dependencyManagement {

--- a/back-gateway/redis-server.yml
+++ b/back-gateway/redis-server.yml
@@ -1,0 +1,19 @@
+## Test Version
+
+version: '3'
+
+services:
+  redis:
+    image: redis:7.2.0-alpine
+    container_name: redis
+    hostname: redis
+    restart: unless-stopped
+    environment:
+      TZ: "Asia/Seoul"
+    ports:
+      - 6379:6379
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      interval: 5s
+      timeout: 3s
+      retries: 10

--- a/back-gateway/src/main/java/com/gateway/backgateway/config/GatewayConfig.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/config/GatewayConfig.java
@@ -61,7 +61,7 @@ public class GatewayConfig {
     //TODO: Custom RedisRateLimiter로 변경 예정
     @Bean
     public RedisRateLimiter redisRateLimiter() {
-        // 기본 replenishRate 및 burstCapacity 값을 지정합니다
+        // 기본 replenishRate 및 burstCapacity 값을 지정합니다.
         return new RedisRateLimiter(20, 60, 3);
     }
 }

--- a/back-gateway/src/main/java/com/gateway/backgateway/config/GatewayConfig.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/config/GatewayConfig.java
@@ -2,6 +2,7 @@ package com.gateway.backgateway.config;
 
 import com.gateway.backgateway.filter.AuthorizationHeaderFilter;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
@@ -32,5 +33,10 @@ public class GatewayConfig {
                         .filters(f->f.filter(authFilter.apply(config -> {config.setRequiredRole("role_user");})))
                         .uri("http://spring:8080"))
                 .build();
+    }
+
+    @Bean
+    public RedisRateLimiter redisRateLimiter() {
+        return new RedisRateLimiter(10, 20, 3);
     }
 }

--- a/back-gateway/src/main/java/com/gateway/backgateway/config/GatewayConfig.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/config/GatewayConfig.java
@@ -3,15 +3,11 @@ package com.gateway.backgateway.config;
 import com.gateway.backgateway.filter.AuthorizationHeaderFilter;
 import com.gateway.backgateway.filter.RequestRateLimitFilter;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.gateway.filter.factory.RequestRateLimiterGatewayFilterFactory;
-import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
 import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.server.ServerWebExchange;
-import reactor.core.publisher.Mono;
 
 @Configuration
 public class GatewayConfig {
@@ -49,18 +45,17 @@ public class GatewayConfig {
                 .route("spring", r -> r.path("/api/**")
                         .filters(f->f
                                 .filter(authFilter.apply(config -> {config.setRequiredRole("role_user");}))
-                                .filter(limitFilter.apply(config -> {
-                                    config.setRateLimiter(redisRateLimiter());
-                                    config.setRouteId("22");
-                                }))
+                                .requestRateLimiter(c -> {
+                                    c.setRateLimiter(redisRateLimiter());
+                                })
                         )
-                        .uri("http://localhost:8080"))
+                        .uri("http://spring:8080"))
                 .build();
     }
 
     @Bean
     public RedisRateLimiter redisRateLimiter() {
-        return new RedisRateLimiter(0, 1, 1); // 기본 replenishRate 및 burstCapacity 값을 지정합니다
+        return new RedisRateLimiter(1, 1, 1); // 기본 replenishRate 및 burstCapacity 값을 지정합니다
     }
 
     public UserIdKeyResolver userKeyResolver() {

--- a/back-gateway/src/main/java/com/gateway/backgateway/config/GatewayConfig.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/config/GatewayConfig.java
@@ -1,12 +1,17 @@
 package com.gateway.backgateway.config;
 
 import com.gateway.backgateway.filter.AuthorizationHeaderFilter;
+import com.gateway.backgateway.filter.RequestRateLimitFilter;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.factory.RequestRateLimiterGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
 import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
 
 @Configuration
 public class GatewayConfig {
@@ -15,28 +20,50 @@ public class GatewayConfig {
 
     @Bean
     public RouteLocator gatewayRoutes(RouteLocatorBuilder builder,
-                                      AuthorizationHeaderFilter authFilter) {
+                                      AuthorizationHeaderFilter authFilter,
+                                      RequestRateLimitFilter limitFilter) {
         return builder.routes()
-                .route("chatbot",r -> r.path("/docs", "/openapi.json")
+                .route("chatbot-docs",r -> r.path("/docs", "/openapi.json")
                         .uri(chatbotUrl))
                 .route("chatbot",r -> r.path("/api/chatbot/**")
-                        .filters(f->f.filter(authFilter.apply(config -> {config.setRequiredRole("role_user");})))
+                        .filters(f->f
+                                .filter(authFilter.apply(config -> {config.setRequiredRole("role_user");}))
+                                .filter(limitFilter.apply(config -> {
+                                    config.setRateLimiter(redisRateLimiter());
+                                    config.setRouteId("chat");
+                                }))
+                        )
                         .uri(chatbotUrl))
-                .route("chat", r -> r.path("/api/chat/**")
-                        .filters(f->f.filter(authFilter.apply(config -> {config.setRequiredRole("role_user");})))
+                .route(r -> r.path("/api/chat/**")
+                        .filters(f->f
+                                .filter(authFilter.apply(config -> {config.setRequiredRole("role_user");}))
+                                .filter(limitFilter.apply(config -> {
+                                    config.setRateLimiter(redisRateLimiter());
+                                    config.setRouteId("chat");
+                                })))
                         .uri("http://ruby:3000"))
-                .route("business", r -> r.path("/api/user/signin", "/api/user/test", "/api/user/signup",
+                .route("nonJwt-spring", r -> r.path("/api/user/signin", "/api/user/test", "/api/user/signup",
                                 "/api/announcement/**", "/api/menu/**", "/api/speech/**", "/api/question/read", "/api/question/list",
                                 "/api/answer/list", "/api/faq/**", "/api/help/read", "/api/help/list", "/api/auth/**", "/api/swagger-ui/**", "/api/api-docs/**")
                         .uri("http://spring:8080"))
-                .route("business", r -> r.path("/api/**")
-                        .filters(f->f.filter(authFilter.apply(config -> {config.setRequiredRole("role_user");})))
-                        .uri("http://spring:8080"))
+                .route("spring", r -> r.path("/api/**")
+                        .filters(f->f
+                                .filter(authFilter.apply(config -> {config.setRequiredRole("role_user");}))
+                                .filter(limitFilter.apply(config -> {
+                                    config.setRateLimiter(redisRateLimiter());
+                                    config.setRouteId("22");
+                                }))
+                        )
+                        .uri("http://localhost:8080"))
                 .build();
     }
 
     @Bean
     public RedisRateLimiter redisRateLimiter() {
-        return new RedisRateLimiter(10, 20, 3);
+        return new RedisRateLimiter(0, 1, 1); // 기본 replenishRate 및 burstCapacity 값을 지정합니다
+    }
+
+    public UserIdKeyResolver userKeyResolver() {
+        return new UserIdKeyResolver();
     }
 }

--- a/back-gateway/src/main/java/com/gateway/backgateway/config/RedisConfig.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.gateway.backgateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    @Primary
+    public ReactiveRedisConnectionFactory reactiveRedisConnectionFactory() {
+        return new LettuceConnectionFactory("redis", 6379);
+    }
+
+    @Bean
+    @Primary
+    public ReactiveRedisTemplate<String, Object> reactiveRedisTemplate(ReactiveRedisConnectionFactory factory) {
+        RedisSerializationContext<String, Object> serializationContext = RedisSerializationContext
+                .<String, Object>newSerializationContext(new StringRedisSerializer())
+                .hashKey(new StringRedisSerializer())
+                .hashValue(new StringRedisSerializer())
+                .build();
+
+        return new ReactiveRedisTemplate<>(factory, serializationContext);
+    }
+}

--- a/back-gateway/src/main/java/com/gateway/backgateway/config/RedisConfig.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.gateway.backgateway.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -12,10 +13,13 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
+    @Value("${spring.data.redis.host}")
+    String redishost;
+
     @Bean
     @Primary
     public ReactiveRedisConnectionFactory reactiveRedisConnectionFactory() {
-        return new LettuceConnectionFactory("redis", 6379);
+        return new LettuceConnectionFactory(redishost, 6379);
     }
 
     @Bean

--- a/back-gateway/src/main/java/com/gateway/backgateway/config/UserIdKeyResolver.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/config/UserIdKeyResolver.java
@@ -1,18 +1,20 @@
 package com.gateway.backgateway.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
-@Configuration
+@Configuration("user-key-resolver")
+@Primary
+@Slf4j
 public class UserIdKeyResolver implements KeyResolver {
     @Override
     public Mono<String> resolve(ServerWebExchange exchange) {
         String userId = exchange.getRequest().getHeaders().getFirst("X-USER-ID");
-        if (userId != null) {
-            return Mono.empty();
-        }
+        log.info("The user id is {}", userId);
         return Mono.just(userId);
     }
 }

--- a/back-gateway/src/main/java/com/gateway/backgateway/config/UserIdKeyResolver.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/config/UserIdKeyResolver.java
@@ -1,0 +1,18 @@
+package com.gateway.backgateway.config;
+
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Configuration
+public class UserIdKeyResolver implements KeyResolver {
+    @Override
+    public Mono<String> resolve(ServerWebExchange exchange) {
+        String userId = exchange.getRequest().getHeaders().getFirst("X-USER-ID");
+        if (userId != null) {
+            return Mono.empty();
+        }
+        return Mono.just(userId);
+    }
+}

--- a/back-gateway/src/main/java/com/gateway/backgateway/exception/ErrorCode.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(500, "C004", "Server Error"),
     INVALID_TYPE_VALUE(400, "C005", "Invalid Type Value"),
     HANDLE_ACCESS_DENIED(403, "C006", "Access is Denied"),
+    TOO_MANY_REQUESTS(429, "C007", "Too Many Requests"),
 
     // JWT Error
     INVALID_JWT_TOKEN(401, "J001", "Invalid JWT Token");

--- a/back-gateway/src/main/java/com/gateway/backgateway/exception/GlobalExceptionHandler.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/exception/GlobalExceptionHandler.java
@@ -17,8 +17,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
-import static com.gateway.backgateway.exception.ErrorCode.INTERNAL_SERVER_ERROR;
-import static com.gateway.backgateway.exception.ErrorCode.INVALID_JWT_TOKEN;
+import static com.gateway.backgateway.exception.ErrorCode.*;
 
 @Slf4j
 @Order(-1)
@@ -41,6 +40,10 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
         response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
         if (ex instanceof JwtTokenInvalidException) {
             errorCode = INVALID_JWT_TOKEN;
+            response.setStatusCode(HttpStatusCode.valueOf(errorCode.getStatus()));
+        }
+        else if (ex instanceof TooManyRequestException) {
+            errorCode = TOO_MANY_REQUESTS;
             response.setStatusCode(HttpStatusCode.valueOf(errorCode.getStatus()));
         }
         else{

--- a/back-gateway/src/main/java/com/gateway/backgateway/exception/GlobalExceptionHandler.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/exception/GlobalExceptionHandler.java
@@ -43,6 +43,10 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
             errorCode = TOO_MANY_REQUESTS;
             response.setStatusCode(HttpStatus.valueOf(errorCode.getStatus()));
         }
+        else if (ex instanceof  BusinessException) {
+            errorCode = ((BusinessException) ex).getErrorCode();
+            response.setStatusCode(HttpStatus.valueOf(String.valueOf(((BusinessException) ex).getErrorCode())));
+        }
         else{
             errorCode = INTERNAL_SERVER_ERROR;
             response.setStatusCode(HttpStatus.valueOf(errorCode.getStatus()));

--- a/back-gateway/src/main/java/com/gateway/backgateway/exception/GlobalExceptionHandler.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/exception/GlobalExceptionHandler.java
@@ -1,16 +1,13 @@
 package com.gateway.backgateway.exception;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gateway.backgateway.dto.ErrorResponse;
-import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
@@ -40,15 +37,15 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
         response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
         if (ex instanceof JwtTokenInvalidException) {
             errorCode = INVALID_JWT_TOKEN;
-            response.setStatusCode(HttpStatusCode.valueOf(errorCode.getStatus()));
+            response.setStatusCode(HttpStatus.valueOf(errorCode.getStatus()));
         }
         else if (ex instanceof TooManyRequestException) {
             errorCode = TOO_MANY_REQUESTS;
-            response.setStatusCode(HttpStatusCode.valueOf(errorCode.getStatus()));
+            response.setStatusCode(HttpStatus.valueOf(errorCode.getStatus()));
         }
         else{
             errorCode = INTERNAL_SERVER_ERROR;
-            response.setStatusCode(HttpStatusCode.valueOf(errorCode.getStatus()));
+            response.setStatusCode(HttpStatus.valueOf(errorCode.getStatus()));
         }
 
 

--- a/back-gateway/src/main/java/com/gateway/backgateway/exception/TooManyRequestException.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/exception/TooManyRequestException.java
@@ -1,0 +1,11 @@
+package com.gateway.backgateway.exception;
+
+public class TooManyRequestException extends BusinessException {
+
+    // 자주 발생할 수 있는 Exception이라 싱글톤화 하는게 좋다고 합니다.
+    public static final TooManyRequestException INSTANCE = new TooManyRequestException();
+
+    private TooManyRequestException() {
+        super(ErrorCode.TOO_MANY_REQUESTS);
+    }
+}

--- a/back-gateway/src/main/java/com/gateway/backgateway/filter/AuthorizationHeaderFilter.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/filter/AuthorizationHeaderFilter.java
@@ -46,6 +46,8 @@ public class AuthorizationHeaderFilter extends AbstractGatewayFilterFactory<Auth
             String token = request.getHeaders()
                     .getFirst(HttpHeaders.AUTHORIZATION).replace("Bearer ", "");
 
+            System.out.println(token);
+
             if (!validateToken(token)) {
                 throw JwtTokenInvalidException.INSTANCE;
             }

--- a/back-gateway/src/main/java/com/gateway/backgateway/filter/AuthorizationHeaderFilter.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/filter/AuthorizationHeaderFilter.java
@@ -11,15 +11,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
-import org.springframework.web.server.ServerWebExchange;
-import reactor.core.publisher.Mono;
 
 import java.security.Key;
-import java.util.Map;
 import java.util.function.Function;
 
 @Component

--- a/back-gateway/src/main/java/com/gateway/backgateway/filter/RequestRateLimitFilter.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/filter/RequestRateLimitFilter.java
@@ -1,0 +1,77 @@
+package com.gateway.backgateway.filter;
+
+import com.gateway.backgateway.config.UserIdKeyResolver;
+import com.gateway.backgateway.exception.BusinessException;
+import com.gateway.backgateway.exception.ErrorCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.cloud.gateway.filter.ratelimit.RateLimiter;
+import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter;
+import org.springframework.cloud.gateway.support.HasRouteId;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import static com.gateway.backgateway.exception.ErrorCode.TOO_MANY_REQUESTS;
+
+@Component
+@Slf4j
+public class RequestRateLimitFilter extends AbstractGatewayFilterFactory<RequestRateLimitFilter.Config> {
+
+    private final KeyResolver defaultKeyResolver;
+    private final RedisRateLimiter defaultRateLimiter;
+
+    public RequestRateLimitFilter(
+            KeyResolver defaultKeyResolver,
+            RedisRateLimiter redisRateLimiter) {
+        super(Config.class);
+        this.defaultKeyResolver = defaultKeyResolver;
+        this.defaultRateLimiter = redisRateLimiter;
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        log.info("여기 필터 지나는지 확인 1111");
+        GatewayFilter filter = (exchange, chain) -> {
+            KeyResolver keyResolver = getOrDefault(config.keyResolver, defaultKeyResolver);
+            RedisRateLimiter rateLimiter = getOrDefault(config.rateLimiter, defaultRateLimiter);
+            String routeId = config.getRouteId();
+            log.info("여기 필터 지나는지 확인 2222222");
+
+            return keyResolver.resolve(exchange)
+                    .doOnNext(key -> log.info("Resolved key: {}", key))
+                    .flatMap(key -> {
+                        log.info("Calling rate limiter with routeId: {} and key: {}", routeId, key);
+                        return rateLimiter.isAllowed(routeId, key);
+                    })
+                    .flatMap(rateLimitResponse -> {
+                        log.info("Rate limiter response: {}", rateLimitResponse);
+                        log.info("여기 필터 지나는지 확인 2222222");
+                        if (rateLimitResponse.isAllowed()) {
+                            return chain.filter(exchange);
+                        } else {
+                            throw new BusinessException(TOO_MANY_REQUESTS);
+                        }
+                    });
+        };
+
+        return filter;
+    }
+
+    private <T> T getOrDefault(T configValue, T defaultValue) {
+        if (configValue != null) return configValue;
+        else return defaultValue;
+    }
+
+    @Getter
+    @Setter
+    public static class Config implements HasRouteId {
+        private KeyResolver keyResolver;
+        private RedisRateLimiter rateLimiter;
+        private String routeId;
+    }
+}

--- a/back-gateway/src/main/java/com/gateway/backgateway/filter/RequestRateLimitFilter.java
+++ b/back-gateway/src/main/java/com/gateway/backgateway/filter/RequestRateLimitFilter.java
@@ -1,22 +1,15 @@
 package com.gateway.backgateway.filter;
 
-import com.gateway.backgateway.config.UserIdKeyResolver;
-import com.gateway.backgateway.exception.BusinessException;
-import com.gateway.backgateway.exception.ErrorCode;
+import com.gateway.backgateway.exception.TooManyRequestException;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
-import org.springframework.cloud.gateway.filter.ratelimit.RateLimiter;
 import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter;
 import org.springframework.cloud.gateway.support.HasRouteId;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-
-import static com.gateway.backgateway.exception.ErrorCode.TOO_MANY_REQUESTS;
 
 @Component
 @Slf4j
@@ -43,18 +36,12 @@ public class RequestRateLimitFilter extends AbstractGatewayFilterFactory<Request
             log.info("여기 필터 지나는지 확인 2222222");
 
             return keyResolver.resolve(exchange)
-                    .doOnNext(key -> log.info("Resolved key: {}", key))
-                    .flatMap(key -> {
-                        log.info("Calling rate limiter with routeId: {} and key: {}", routeId, key);
-                        return rateLimiter.isAllowed(routeId, key);
-                    })
+                    .flatMap(key -> rateLimiter.isAllowed(routeId, key))
                     .flatMap(rateLimitResponse -> {
-                        log.info("Rate limiter response: {}", rateLimitResponse);
-                        log.info("여기 필터 지나는지 확인 2222222");
                         if (rateLimitResponse.isAllowed()) {
                             return chain.filter(exchange);
                         } else {
-                            throw new BusinessException(TOO_MANY_REQUESTS);
+                            throw TooManyRequestException.INSTANCE;
                         }
                     });
         };

--- a/back-gateway/src/main/resources/application.yml
+++ b/back-gateway/src/main/resources/application.yml
@@ -13,7 +13,7 @@ jwt:
     key: ${JWT_SECRET}
 
 server:
-  port: 8082
+  port: 8081
   chatbot-url: ${CHATBOT_URL}
 
 logging:

--- a/back-gateway/src/main/resources/application.yml
+++ b/back-gateway/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+      data: 0
 
 
 jwt:
@@ -12,5 +13,10 @@ jwt:
     key: ${JWT_SECRET}
 
 server:
-  port: 8081
+  port: 8082
   chatbot-url: ${CHATBOT_URL}
+
+logging:
+  level:
+    root: debug
+

--- a/back-gateway/src/main/resources/application.yml
+++ b/back-gateway/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 spring:
   application:
     name: back-gateway
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
 
 jwt:
   secret:

--- a/back/src/main/java/com/example/capstone/domain/announcement/controller/AnnouncementController.java
+++ b/back/src/main/java/com/example/capstone/domain/announcement/controller/AnnouncementController.java
@@ -99,14 +99,14 @@ public class AnnouncementController {
             @RequestParam(defaultValue = "KO", value = "language") String language,
             @Parameter(description = "어디까지 로드됐는지 가르키는 커서입니다. 입력하지 않으면 처음부터 10개 받아옵니다.")
             @RequestParam(defaultValue = "0", value = "cursor") long cursor,
-            @RequestBody AnnouncementSearchListRequest request
+            @Parameter(description = "검색어입니다. 문자열을 인코딩해서 보내주셔야됩니다.")
+            @RequestParam(value = "word") String word
     ) {
-
-        if (request.word().length() < 2) throw new BusinessException(SEARCH_TOO_SHORT);
+        if (word.length() < 2) throw new BusinessException(SEARCH_TOO_SHORT);
 
 
         Slice<AnnouncementListResponse> slice = announcementSearchService.getAnnouncementSearchList(cursor, type,
-                language, request.word());
+                language, word);
 
         List<AnnouncementListResponse> announcements = slice.getContent();
         boolean hasNext = slice.hasNext();


### PR DESCRIPTION
## Overview

Api Rate Limiter 개발 완료했습니다.

### Related Issue
Issue Number : closed #159 #167

## Task Details

### API Rate Limiter가 필요한 이유
A라는 사람이 악의적으로 우리 AI 모델에게 1분에 100만번의 요청을 보낼 수 있습니다. 그러면 우리 AI Token은 모두 사라진다. B라는 사람은 Spring 비즈니스 서버에 1초에 1000만번 요청을 날릴 수 있습니다. 그러면, 역시 서버가 터질 것입니다. 그래서 API Gateway가 서버와 클라이언트 사이에서 미들웨어 역할을 하여 분당 API 사용량을 제한해줍니다.

![image](https://github.com/kookmin-sw/capstone-2024-30/assets/55117706/612ed130-224f-46f3-8f4d-7641a9a4e258)

실제로 카카오톡도 위에 사진 처럼 API Rate Limiter가 적용되어있습니다.

### API Rate Limiter 작동 원리

![image](https://github.com/kookmin-sw/capstone-2024-30/assets/55117706/747882ae-dd03-43b5-b531-e08dbd99d3c2)

Token Bucket Algorithm을 이용하여 개발되었습니다. 사용자가 최대 가질 수 있는 Token Bucket Capacity가 정해져 있습니다. 그리고 계속, 지속적으로 일정시간마다 Token이 리필이 됩니. 이 Token 리필은 Bucket Size가 꽉찼을때는 되지 않습니다. 그리고, 사용자가 API 요청을 보낼 때 마다 Bucket에서 Token을 꺼내갑니다. 만약, 꺼낼 Token이 없다면,  Status 429를 보내줍니다. (Too Many Requests) 이외에도 출 버킷 알고리즘, 고정 윈도 카운터 알고리즘, 이동 윈도 로깅 알고리즘, 이동 윈도 카운터 알고리즘 등이 존재합니다.

![image](https://github.com/kookmin-sw/capstone-2024-30/assets/55117706/45458ae2-052a-4e14-8fb2-c5908e7b85ae)

Spring Cloud Gateway는 위에처럼 Redis를 이용하여 구현합니다. Redis에 {사용자 UUID}.token = 20 이런식으로 기록해두고, 이 값을 조정하는 방식입니다.

Redis는 인메모리 DB이기 때문에 매우 빠릅니다. 또한, Redis의 또다른 특징은 싱글 스레드에서 실행된다는 것입니다. 그래서, 다중 사용자의 요청에도 일관되게 처리할 수 있습니다. 즉, Race Condition을 예방할 수 있습니다.

하지만, Redis 내부에서는 싱글 스레드로 실행되지만, 이는 Redis의 Value 값을 증가시키거나 이런 일련의 하나의 행위에만 해당하는 일입니다. 실제 코드를 작성할 때는, (Redis로 부터 값을 읽옴) → (읽어온 값을 보고 Redis에 값을 처리) 이런 로직으로 진행됨. 이 과정은 Spring 코드 내에서 실행될 것인데, 그럼 만약에 동시에 99명의 사용자가 Redis로 부터 값을 읽으면, 모두가 같은 값을 읽어갑니다. 즉, Redis로 부터 읽고, 읽어온 값을 보고 Reids에 다시 값을 반영하는 이 일련의 행위가 하나의 덩어리로 이루어져야 한다는 말입니다. 아닐경우 결국 Race Condition 발생합니다.

그래서 Redis 2.6버전 부터는 내장된 Lua Script Engine으로 Lua Script를 실행할 수 있습니다. 이 일련의 행위를 Lua Script로 짜서 Redis 내부에서 실행하면 Atomic하게 실행될 것이고, Race Condition을 방지할 수 있습니다.

### API Rate Limiter 구현

![image](https://github.com/kookmin-sw/capstone-2024-30/assets/55117706/97da249b-0446-4abe-9a6b-2b9d86c7142b)

위에처럼 Filter를 하나 만들어 작동하도록 만들었습니다. 라우팅 될 때, JWT Auth Filter를 거치고, 거기서 X-User-ID를 추출해서 Rate Limiter로 넘겨줍니다. 그 다음 Rate Limiter는 이를 Key값으로 작동됩니다.

![image](https://github.com/kookmin-sw/capstone-2024-30/assets/55117706/a98c27fd-9ebc-4363-821f-31a20c7b8ee9)

만약, 너무 많은 요청이 오면 위에처럼 오류가 나옵니다. 현재 설정으로는 초반에 최대 20개의 요청을 처리할 수 있고, 이후에는 매초 최대 약 6~7개의 요청을 꾸준히 처리할 수 있도록 수치를 조정해놨습니다.

하지만, 현재는 RedisRateLimiter를 그대로 가져다 쓰는 상태인데, 이 RateLimiter도 Custom해서 쓸 수 있습니다. 이러면 좀 더 세부적인 처리가 가능해집니다. 이는 추후 시간나면 고쳐보도록 하겠습니다.

### API Rate Limiter가 Lua 스크립트를 읽지 못하는 현상

[해당 Issue 답글에 해결법을 달아놨습니다](https://github.com/kookmin-sw/capstone-2024-30/issues/167)

## Test Scope & Checklist (Optional)

> Please explain test scope, task, plan, method
- [ ] API Rate Limiter 작동 확

## Review Requirements

Test는 Redis 5.0이상에서 진행하셔야 원활하게 진행될 것 입니다.