### PR TITLE
Refactor/be/#180 게시글 작성 content-type mapping 및 S3 이미지 용량 제한

### DIFF
--- a/back/src/main/java/com/example/capstone/domain/qna/service/ImageService.java
+++ b/back/src/main/java/com/example/capstone/domain/qna/service/ImageService.java
@@ -71,7 +71,7 @@ public class ImageService {
     }
 
     private String uploadImage(MultipartFile image) {
-        this.validateImageFileExtention(image.getOriginalFilename());
+        this.validateImageFileExtension(image.getOriginalFilename());
         try {
             return this.uploadImageToS3(image);
         } catch (IOException e) {
@@ -79,23 +79,23 @@ public class ImageService {
         }
     }
 
-    private void validateImageFileExtention(String filename) {
+    private void validateImageFileExtension(String filename) {
         int lastDotIndex = filename.lastIndexOf(".");
         if (lastDotIndex == -1) {
-            throw new BusinessException(ErrorCode.NO_FILE_EXTENTION);
+            throw new BusinessException(ErrorCode.NO_FILE_EXTENSION);
         }
 
-        String extention = filename.substring(lastDotIndex + 1).toLowerCase();
-        List<String> allowedExtentionList = Arrays.asList("jpg", "jpeg", "png", "gif");
+        String extension = filename.substring(lastDotIndex + 1).toLowerCase();
+        List<String> allowedExtensionList = Arrays.asList("jpg", "jpeg", "png", "gif");
 
-        if (!allowedExtentionList.contains(extention)) {
-            throw new BusinessException(ErrorCode.INVALID_FILE_EXTENTION);
+        if (!allowedExtensionList.contains(extension)) {
+            throw new BusinessException(ErrorCode.INVALID_FILE_EXTENSION);
         }
     }
 
     private String uploadImageToS3(MultipartFile image) throws IOException {
         String originalFilename = image.getOriginalFilename();
-        String extention = originalFilename.substring(originalFilename.lastIndexOf("."));
+        String extension = originalFilename.substring(originalFilename.lastIndexOf("."));
 
         String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename;
 
@@ -103,7 +103,7 @@ public class ImageService {
         byte[] bytes = IOUtils.toByteArray(is);
 
         ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentType("image/" + extention);
+        metadata.setContentType("image/" + extension);
         metadata.setContentLength(bytes.length);
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
 

--- a/back/src/main/java/com/example/capstone/global/config/WebConfig.java
+++ b/back/src/main/java/com/example/capstone/global/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.example.capstone.global.config;
+
+import com.example.capstone.global.converter.OctetStreamReadMsgConverter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private OctetStreamReadMsgConverter octetStreamReadMsgConverter;
+
+    @Autowired
+    public WebConfig(OctetStreamReadMsgConverter octetStreamReadMsgConverter) {
+        this.octetStreamReadMsgConverter = octetStreamReadMsgConverter;
+    }
+
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        converters.add(octetStreamReadMsgConverter);
+    }
+}

--- a/back/src/main/java/com/example/capstone/global/converter/OctetStreamReadMsgConverter.java
+++ b/back/src/main/java/com/example/capstone/global/converter/OctetStreamReadMsgConverter.java
@@ -1,0 +1,32 @@
+package com.example.capstone.global.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class OctetStreamReadMsgConverter extends AbstractJackson2HttpMessageConverter {
+    @Autowired
+    public OctetStreamReadMsgConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/back/src/main/java/com/example/capstone/global/error/GlobalExceptionHandler.java
+++ b/back/src/main/java/com/example/capstone/global/error/GlobalExceptionHandler.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.nio.file.AccessDeniedException;
@@ -64,6 +66,19 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ApiResult<?>> handleJwtTokenInvalidException(final JwtTokenInvalidException e){
         log.error("handleJwtTokenInvalid", e);
         final ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(new ApiResult<>(errorCode));
+    }
+
+    /*
+    * 업로드 파일 용량이 최대 용량보다 초과시 발생
+    * */
+    @ExceptionHandler(MultipartException.class)
+    @ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
+    protected ResponseEntity<ApiResult<?>> handleMaxUploadSizeExceededException (final MultipartException e){
+        log.error("handleMaxUploadSizeExceededException", e);
+        final ErrorCode errorCode = ErrorCode.MAX_SIZE_UPLOAD_EXCEED;
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(new ApiResult<>(errorCode));

--- a/back/src/main/java/com/example/capstone/global/error/exception/ErrorCode.java
+++ b/back/src/main/java/com/example/capstone/global/error/exception/ErrorCode.java
@@ -35,10 +35,11 @@ public enum ErrorCode {
     // S3 Error
     EMPTY_FILE_EXCEPTION(400, "S301", "File is empty"),
     IO_EXCEPTION_ON_IMAGE_UPLOAD(400, "S302", "Io exception on image"),
-    NO_FILE_EXTENTION(400, "S303", "Not found file"),
-    INVALID_FILE_EXTENTION(400, "S304", "File is invalid"),
+    NO_FILE_EXTENSION(400, "S303", "Not found file"),
+    INVALID_FILE_EXTENSION(400, "S304", "File is invalid"),
     PUT_OBJECT_EXCEPTION(400, "S305", "Object can not put"),
     IO_EXCEPTION_ON_IMAGE_DELETE(400, "S306", "Io exception on image delete"),
+    MAX_SIZE_UPLOAD_EXCEED(400, "S307", "File size exceeded the max size"),
 
     // HMAC
     HMAC_NOT_VALID(403, "HM001", "HMAC is not valid"),

--- a/back/src/main/resources/application.properties
+++ b/back/src/main/resources/application.properties
@@ -26,6 +26,13 @@ s3.bucket.name=capstone-30-backend
 s3.region.static=ap-northeast-2
 s3.stack.auto=false
 
+spring.servlet.multipart.resolve-lazily=true
+spring.servlet.multipart.max-file-size=100MB
+spring.servlet.multipart.max-request-size=500MB
+
+server.tomcat.max-swallow-size=200MB
+server.tomcat.max-http-form-post-size=200MB
+
 hmac.secret=${HMAC_SECRET}
 hmac.algorithm=${HMAC_ALGORITHM}
 


### PR DESCRIPTION
## Overview

게시글 작성을 위한 content-type mapping 과 S3 이미지 용량 제한을 설정하였다.

### Related Issue

Issue Number : #180 

## Task Details

기존 게시글 코드는 각 파라미터 별 content-type을 설정하는 것이 가능하다는 전제하에 작성하였다. (Ex : postman)
그러나 프론트엔드에서 Flutter는 해당 기능이 없다고 하여 multipart/form-data로 json 데이터를 application/octet-stream으로 바꾸어 주는 config 파일과 converter를 작성하였다.

multipart/form-data의 content-type으로 json 데이터를 받기 위해서 기존의 httpMessageConverter는 application/octet-stream을 지원하지 않아 해당 content-type으로 전환해주는 converter를 작성하였다.

추가로 이미지 첨부 용량 증가 및 한도 설정을 위해 application.properties에 환경변수를 첨부하고 예외처리 코드를 작성하였다. 해당 작업에 있어 Spring boot 버전차이, Tomcat 파일 용량 처리, MVC 입력처리 등으로 인한 난항이 있었다.

![image](https://github.com/kookmin-sw/capstone-2024-30/assets/53148103/7f8e9fba-e3e1-46b1-9fab-61975af53703)
예외처리 성공 화면

![image](https://github.com/kookmin-sw/capstone-2024-30/assets/53148103/027aa562-0b71-43d5-8c41-1caf5b409062)
게시글 작성 성공 화면

## Test Scope & Checklist (Optional)

- [ ] 용량에 따른 이미지 업로드 여부
- [ ] 게시글 작성 및 이미지 첨부 가능

## Review Requirements