### PR TITLE
[FE] qna 게시글 작성 구현 및 헬퍼, qna 작성 데이터 유저 데이터로 변경

### DIFF
--- a/front/capstone_front/lib/screens/helper/helper_write_screen.dart
+++ b/front/capstone_front/lib/screens/helper/helper_write_screen.dart
@@ -3,6 +3,7 @@ import 'package:capstone_front/utils/basic_button.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:go_router/go_router.dart';
 
 class HelperWriteScreen extends StatefulWidget {
@@ -93,19 +94,21 @@ class _HelperWriteScreenState extends State<HelperWriteScreen> {
             BasicButton(
               text: tr('helper.write_complete'),
               onPressed: () async {
-                setState(() {
-                  if (_titleController.text != "" &&
-                      _contentController.text != "") {
-                    var result = HelperService.createHelperPost({
-                      "title": _titleController.text,
-                      "author": "지훈초이",
-                      "country": "korea",
-                      "context": _contentController.text,
-                      "isHelper": _selectedIndex
-                    });
-                    Navigator.pop(context, result);
-                  }
-                });
+                if (_titleController.text != "" &&
+                    _contentController.text != "") {
+                  FlutterSecureStorage storage = const FlutterSecureStorage();
+
+                  var author = await storage.read(key: "userName");
+                  var country = await storage.read(key: "userCountry");
+                  var result = HelperService.createHelperPost({
+                    "title": _titleController.text,
+                    "author": author,
+                    "country": country,
+                    "context": _contentController.text,
+                    "isHelper": _selectedIndex
+                  });
+                  Navigator.pop(context, result);
+                }
               },
             )
           ],

--- a/front/capstone_front/lib/screens/qna/qna_write/qna_write_screen.dart
+++ b/front/capstone_front/lib/screens/qna/qna_write/qna_write_screen.dart
@@ -221,19 +221,6 @@ class _HelperWriteScreenState extends State<QnaWriteScreen> {
                   // id를 리턴받아서 qnas list에 넣기
                   // Map<String, dynamic> res =
                   //     await QnaService.createQnaPost(articleInfo, images);
-                  widget.qnas.insert(
-                      0,
-                      QnaPostModel(
-                        id: 1,
-                        title: _titleController.text,
-                        author: "author",
-                        content: _contentController.text,
-                        category: "category",
-                        country: "country",
-                        answerCount: 2,
-                        createdDate: "2024-05-04",
-                      ));
-
                   var qnaPost = {
                     "title": _titleController.text,
                     "author": "author",
@@ -241,7 +228,22 @@ class _HelperWriteScreenState extends State<QnaWriteScreen> {
                     "tag": "tagggg",
                     "country": "qwe",
                   };
-                  QnaService.createQnaPost(qnaPost, images);
+                  var res = await QnaService.createQnaPost(qnaPost, images);
+                  print(res);
+                  print('@@@@@');
+
+                  widget.qnas.insert(
+                      0,
+                      QnaPostModel(
+                        id: res['questionResponse']['id'],
+                        title: res['questionResponse']['title'],
+                        author: res['questionResponse']['author'],
+                        content: res['questionResponse']['context'],
+                        category: res['questionResponse']['tag'],
+                        country: res['questionResponse']['country'],
+                        answerCount: 0,
+                        createdDate: res['questionResponse']['createdDate'],
+                      ));
                   Navigator.pop(context);
                 } else {
                   makeToast("내용을 다 채워주세요");

--- a/front/capstone_front/lib/screens/qna/qna_write/qna_write_screen.dart
+++ b/front/capstone_front/lib/screens/qna/qna_write/qna_write_screen.dart
@@ -7,6 +7,7 @@ import 'package:capstone_front/utils/basic_button.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:image_picker/image_picker.dart';
 
 class QnaWriteScreen extends StatefulWidget {
@@ -221,12 +222,17 @@ class _HelperWriteScreenState extends State<QnaWriteScreen> {
                   // id를 리턴받아서 qnas list에 넣기
                   // Map<String, dynamic> res =
                   //     await QnaService.createQnaPost(articleInfo, images);
+
+                  FlutterSecureStorage storage = const FlutterSecureStorage();
+
+                  var author = await storage.read(key: "userName");
+                  var country = await storage.read(key: "userCountry");
                   var qnaPost = {
                     "title": _titleController.text,
-                    "author": "author",
+                    "author": author,
                     "context": _contentController.text,
-                    "tag": "tagggg",
-                    "country": "qwe",
+                    "tag": _helperWriteList[_selectedIndex].toString(),
+                    "country": country,
                   };
                   var res = await QnaService.createQnaPost(qnaPost, images);
                   print(res);

--- a/front/capstone_front/lib/services/auth_service.dart
+++ b/front/capstone_front/lib/services/auth_service.dart
@@ -107,6 +107,8 @@ class AuthService {
       UserInfoModel userInfoModel = UserInfoModel.fromJson(jsonMap['response']);
       await storage.write(key: "userName", value: userInfoModel.name);
       await storage.write(key: "userMajor", value: userInfoModel.major);
+      await storage.write(key: "userEmail", value: userInfoModel.email);
+      await storage.write(key: "userCountry", value: userInfoModel.country);
     } else {
       var apiFailResponse = ApiFailResponse.fromJson(jsonMap);
       print(apiFailResponse.message);

--- a/front/capstone_front/lib/services/qna_service.dart
+++ b/front/capstone_front/lib/services/qna_service.dart
@@ -11,6 +11,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:image_picker/image_picker.dart';
 import 'dart:io';
+import 'package:http_parser/http_parser.dart';
 
 class QnaService {
   static String baseUrl = dotenv.get('BASE_URL');
@@ -146,7 +147,20 @@ class QnaService {
     final url = Uri.parse('$baseUrl/question/create');
 
     var request = http.MultipartRequest('POST', url);
-    request.fields['request'] = jsonEncode(qnaPost);
+
+    // JSON 데이터를 UTF-8로 인코딩하여 바이트로 변환 후 MultipartFile로 추가
+    List<int> jsonData = utf8.encode(jsonEncode(qnaPost));
+    request.files.add(http.MultipartFile.fromBytes(
+      'request',
+      jsonData,
+      contentType: MediaType(
+        'application',
+        'json',
+        {'charset': 'utf-8'},
+      ),
+    ));
+
+    // request.fields['request'] = jsonEncode(qnaPost);
     request.headers['Authorization'] = 'Bearer $accessToken';
     request.headers['Content-Type'] = 'multipart/form-data';
 

--- a/front/capstone_front/lib/services/qna_service.dart
+++ b/front/capstone_front/lib/services/qna_service.dart
@@ -167,7 +167,7 @@ class QnaService {
     final bytes = await response.stream.toBytes();
     final String decodedBody = utf8.decode(bytes);
     final Map<String, dynamic> jsonMap = jsonDecode(decodedBody);
-    if (response.statusCode == 201) {
+    if (response.statusCode == 200) {
       // TODO 게시글 id 리턴받아서, 게시글 객체 완성한 다음에 리스트에 추가 및 띄워주기
       ApiSuccessResponse apiSuccessResponse =
           ApiSuccessResponse.fromJson(jsonMap);
@@ -195,6 +195,7 @@ class QnaService {
       url,
       headers: {
         'Authorization': 'Bearer $accessToken',
+        'Content-Type': 'application/json',
       },
       body: jsonEncode(answer),
     );
@@ -210,7 +211,9 @@ class QnaService {
 
       return answerModel;
     } else {
+      var apiFailResponse = ApiFailResponse.fromJson(jsonMap);
       print('Request failed with status: ${response.statusCode}.');
+      print('Request failed with status: ${apiFailResponse.message}.');
       throw Exception('Failed to load notices');
     }
   }

--- a/front/capstone_front/pubspec.yaml
+++ b/front/capstone_front/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
   record: ^5.0.5
   change_app_package_name: ^1.1.0
   photo_view: ^0.15.0
+  http_parser: ^4.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Overview

> qna 게시글 작성 구현 및 헬퍼, qna 작성 데이터 유저 데이터로 변경

### Related Issue

Issue Number : #137 

## Task Details

- 서버에서 요청을 받는 형식을 변경함에 따라 게시글 작성이 가능해짐
- 서버에 요청을 보내는 데이터가 일부 더미데이터 였으나, 전부 실제 데이터로 변경
- 한글을 multipart에 포함시켜 보낼 수 없는 문제를 해결하기 위해 http_parser 패키지를 설치하여 사용함


## Test Scope & Checklist (Optional)

- [ ] 사진 없이 or 사진 포함하여 QnA게시글이 잘 작성이 되는지
- [ ] 한글 or 영어로 게시글 작성이 가능한지
