### PR TITLE
Feature/fe/#212 faq search

### DIFF
--- a/front/capstone_front/lib/main.dart
+++ b/front/capstone_front/lib/main.dart
@@ -272,7 +272,10 @@ final GoRouter router = GoRouter(
     GoRoute(
       name: 'faq',
       path: '/faq',
-      builder: (context, state) => const FaqScreen(),
+      builder: (context, state) => FaqScreen(
+        performSearch: (text) {},
+        searchController: TextEditingController(),
+      ),
     ),
     GoRoute(
       name: 'question',

--- a/front/capstone_front/lib/screens/faq/faq_screen.dart
+++ b/front/capstone_front/lib/screens/faq/faq_screen.dart
@@ -12,6 +12,28 @@ class FaqScreenState extends State<FaqScreen> {
   String selectedItem = 'major';
   String selectedItemToShow = '전공';
   final _controller = TextEditingController();
+  List<Map<String, dynamic>> filteredFaqs = [];
+
+  @override
+  void initState() {
+    super.initState();
+    filteredFaqs = faqs[selectedItem]!;
+  }
+
+  void _filterFaqs(String query) {
+    final List<Map<String, dynamic>> allFaqs = faqs[selectedItem]!;
+    if (query.isEmpty) {
+      filteredFaqs = allFaqs;
+    } else {
+      filteredFaqs = allFaqs.where((faq) {
+        final title = faq['title'].toLowerCase();
+        final content = faq['content'].toLowerCase();
+        final searchQuery = query.toLowerCase();
+        return title.contains(searchQuery) || content.contains(searchQuery);
+      }).toList();
+    }
+    setState(() {});
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +43,7 @@ class FaqScreenState extends State<FaqScreen> {
         title: TextField(
           controller: _controller,
           onChanged: (text) {
-            setState(() {});
+            _filterFaqs(text);
           },
           decoration: InputDecoration(
             hintText: "검색어를 입력하세요",
@@ -33,7 +55,7 @@ class FaqScreenState extends State<FaqScreen> {
                 ? IconButton(
                     onPressed: () {
                       _controller.clear();
-                      setState(() {});
+                      _filterFaqs('');
                     },
                     icon: const Icon(
                       Icons.cancel,
@@ -93,6 +115,7 @@ class FaqScreenState extends State<FaqScreen> {
                                       setState(() {
                                         selectedItem = faqCategoryMapper[item]!;
                                         selectedItemToShow = item;
+                                        filteredFaqs = faqs[selectedItem]!;
                                       });
                                       Navigator.of(context).pop();
                                     },
@@ -136,13 +159,13 @@ class FaqScreenState extends State<FaqScreen> {
           ),
           Expanded(
             child: ListView.separated(
-              itemCount: faqs[selectedItem]!.length,
+              itemCount: filteredFaqs.length,
               itemBuilder: (context, index) {
                 return Theme(
                   data: ThemeData().copyWith(dividerColor: Colors.transparent),
                   child: ExpansionTile(
                     title: Text(
-                      faqs[selectedItem]![index]['title'],
+                      filteredFaqs[index]['title'],
                       overflow: TextOverflow.ellipsis,
                       style: const TextStyle(
                         fontSize: 18,
@@ -151,7 +174,7 @@ class FaqScreenState extends State<FaqScreen> {
                     children: <Widget>[
                       ListTile(
                         subtitle: Text(
-                          faqs[selectedItem]![index]['content'],
+                          filteredFaqs[index]['content'],
                         ),
                       ),
                     ],
@@ -165,7 +188,7 @@ class FaqScreenState extends State<FaqScreen> {
                 ),
               ),
             ),
-          )
+          ),
         ],
       ),
     );

--- a/front/capstone_front/lib/screens/faq/faq_screen.dart
+++ b/front/capstone_front/lib/screens/faq/faq_screen.dart
@@ -2,7 +2,11 @@ import 'package:capstone_front/screens/faq/test_faq_data.dart';
 import 'package:flutter/material.dart';
 
 class FaqScreen extends StatefulWidget {
-  const FaqScreen({super.key});
+  final Function(String) performSearch;
+  final TextEditingController searchController;
+
+  const FaqScreen(
+      {super.key, required this.performSearch, required this.searchController});
 
   @override
   State<FaqScreen> createState() => FaqScreenState();
@@ -11,16 +15,18 @@ class FaqScreen extends StatefulWidget {
 class FaqScreenState extends State<FaqScreen> {
   String selectedItem = 'major';
   String selectedItemToShow = '전공';
-  final _controller = TextEditingController();
   List<Map<String, dynamic>> filteredFaqs = [];
 
   @override
   void initState() {
     super.initState();
     filteredFaqs = faqs[selectedItem]!;
+    widget.searchController.addListener(() {
+      widget.performSearch(widget.searchController.text);
+    });
   }
 
-  void _filterFaqs(String query) {
+  void filterFaqs(String query) {
     final List<Map<String, dynamic>> allFaqs = faqs[selectedItem]!;
     if (query.isEmpty) {
       filteredFaqs = allFaqs;
@@ -35,50 +41,18 @@ class FaqScreenState extends State<FaqScreen> {
     setState(() {});
   }
 
+  void changeCategory(String category) {
+    setState(() {
+      selectedItem = faqCategoryMapper[category]!;
+      selectedItemToShow = category;
+      filteredFaqs = faqs[selectedItem]!;
+      widget.performSearch(widget.searchController.text);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        scrolledUnderElevation: 0,
-        title: TextField(
-          controller: _controller,
-          onChanged: (text) {
-            _filterFaqs(text);
-          },
-          decoration: InputDecoration(
-            hintText: "검색어를 입력하세요",
-            border: InputBorder.none,
-            hintStyle: const TextStyle(
-              color: Color(0XFFd7d7d7),
-            ),
-            suffixIcon: _controller.text.isNotEmpty
-                ? IconButton(
-                    onPressed: () {
-                      _controller.clear();
-                      _filterFaqs('');
-                    },
-                    icon: const Icon(
-                      Icons.cancel,
-                      color: Colors.grey,
-                    ),
-                  )
-                : null,
-          ),
-          style: const TextStyle(
-            color: Colors.black,
-            fontSize: 18.0,
-          ),
-        ),
-        actions: [
-          IconButton(
-            icon: Icon(
-              Icons.search,
-              color: Theme.of(context).primaryColor,
-            ),
-            onPressed: () => {},
-          ),
-        ],
-      ),
       body: Column(
         children: [
           Padding(
@@ -112,11 +86,7 @@ class FaqScreenState extends State<FaqScreen> {
                                 ...faqKinds.map(
                                   (item) => ListTile(
                                     onTap: () {
-                                      setState(() {
-                                        selectedItem = faqCategoryMapper[item]!;
-                                        selectedItemToShow = item;
-                                        filteredFaqs = faqs[selectedItem]!;
-                                      });
+                                      changeCategory(item);
                                       Navigator.of(context).pop();
                                     },
                                     title: Center(

--- a/front/capstone_front/lib/screens/qna/qna_list_screen/qna_list_screen.dart
+++ b/front/capstone_front/lib/screens/qna/qna_list_screen/qna_list_screen.dart
@@ -11,16 +11,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
-GlobalKey<_QnaListScreenState> qnaListScreenGlobalKey = GlobalKey();
+GlobalKey<QnaListScreenState> qnaListScreenGlobalKey = GlobalKey();
 
 class QnaListScreen extends StatefulWidget {
   const QnaListScreen({super.key});
 
   @override
-  State<QnaListScreen> createState() => _QnaListScreenState();
+  State<QnaListScreen> createState() => QnaListScreenState();
 }
 
-class _QnaListScreenState extends State<QnaListScreen> {
+class QnaListScreenState extends State<QnaListScreen> {
   final _controller = TextEditingController();
 
   List<QnaPostModel> qnas = [];

--- a/front/capstone_front/lib/screens/qna/qna_list_screen/qna_list_screen.dart
+++ b/front/capstone_front/lib/screens/qna/qna_list_screen/qna_list_screen.dart
@@ -73,13 +73,10 @@ class _QnaListScreenState extends State<QnaListScreen> {
       } else {
         selectedTag = tag;
       }
-    });
-    setState(() {
       qnas = [];
       cursor = 0;
       hasNext = true;
       itemCount = 0;
-      word = null;
     });
     loadQnas(0, selectedTag, word);
   }
@@ -233,98 +230,6 @@ class _QnaListScreenState extends State<QnaListScreen> {
           fontWeight: FontWeight.w700,
         ),
       ),
-    );
-  }
-}
-
-class MyCustomBottomSheet extends StatefulWidget {
-  const MyCustomBottomSheet({super.key});
-
-  @override
-  _MyCustomBottomSheetState createState() => _MyCustomBottomSheetState();
-}
-
-class _MyCustomBottomSheetState extends State<MyCustomBottomSheet> {
-  bool productInfo = false;
-  bool ingredientInfo = false;
-  bool nutritionAnalysis = false;
-  bool others = false;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min, // 컨텐츠 크기에 맞춰 조정
-      children: <Widget>[
-        Text(
-          tr('qna.writetitle'),
-          style: const TextStyle(fontSize: 24.0, fontWeight: FontWeight.w700),
-        ),
-        const SizedBox(
-          height: 30,
-        ),
-        CheckboxListTile(
-          title: Text(tr('qna.category_1')),
-          value: productInfo,
-          activeColor: Theme.of(context).primaryColor,
-          checkColor: Colors.white,
-          onChanged: (bool? value) {
-            setState(() {
-              productInfo = value!;
-            });
-          },
-        ),
-        const Divider(
-          color: Color(0xFFc9c9c9),
-        ),
-        CheckboxListTile(
-          title: Text(tr('qna.category_2')),
-          value: ingredientInfo,
-          activeColor: Theme.of(context).primaryColor,
-          checkColor: Colors.white,
-          onChanged: (bool? value) {
-            setState(() {
-              ingredientInfo = value!;
-            });
-          },
-        ),
-        const Divider(
-          color: Color(0xFFc9c9c9),
-        ),
-        CheckboxListTile(
-          title: Text(tr('qna.category_3')),
-          value: nutritionAnalysis,
-          activeColor: Theme.of(context).primaryColor,
-          checkColor: Colors.white,
-          onChanged: (bool? value) {
-            setState(() {
-              nutritionAnalysis = value!;
-            });
-          },
-        ),
-        const Divider(
-          color: Color(0xFFc9c9c9),
-        ),
-        CheckboxListTile(
-          title: Text(tr('qna.category_4')),
-          value: others,
-          activeColor: Theme.of(context).primaryColor,
-          checkColor: Colors.white,
-          onChanged: (bool? value) {
-            setState(() {
-              others = value!;
-            });
-          },
-        ),
-        const SizedBox(
-          height: 30,
-        ),
-        BasicButton(
-          text: "선택완료",
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
-        ),
-      ],
     );
   }
 }

--- a/front/capstone_front/lib/screens/question/question_screen.dart
+++ b/front/capstone_front/lib/screens/question/question_screen.dart
@@ -4,6 +4,9 @@ import 'package:capstone_front/utils/search_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+GlobalKey<QnaListScreenState> qnaListScreenGlobalKey = GlobalKey();
+GlobalKey<FaqScreenState> faqScreenGlobalKey = GlobalKey();
+
 class QuestionScreen extends StatefulWidget {
   const QuestionScreen({super.key});
 
@@ -13,26 +16,52 @@ class QuestionScreen extends StatefulWidget {
 
 class _QuestionScreenState extends State<QuestionScreen> {
   int _selectedPageIndex = 0;
-  final _qnaScreenList = [
-    QnaListScreen(key: qnaListScreenGlobalKey),
-    const FaqScreen(),
-  ];
+  late List<Widget> _qnaScreenList;
+  late FaqScreen faqScreen;
 
   String qnaSearchWord = '';
+  String faqSearchWord = '';
   final _searchController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    faqScreen = FaqScreen(
+      key: faqScreenGlobalKey,
+      performSearch: (text) {
+        _performSearch(text);
+      },
+      searchController: _searchController, // 추가된 부분
+    );
+    _qnaScreenList = [
+      QnaListScreen(key: qnaListScreenGlobalKey),
+      faqScreen,
+    ];
+  }
 
   void _clearSearch() {
     setState(() {
-      qnaSearchWord = '';
+      if (_selectedPageIndex == 0) {
+        qnaSearchWord = '';
+        qnaListScreenGlobalKey.currentState?.searchQna('');
+      } else {
+        faqSearchWord = '';
+        faqScreenGlobalKey.currentState?.filterFaqs('');
+        _searchController.clear();
+      }
     });
-    qnaListScreenGlobalKey.currentState?.searchQna('');
   }
 
   void _performSearch(String text) {
     setState(() {
-      qnaSearchWord = text;
+      if (_selectedPageIndex == 0) {
+        qnaSearchWord = text;
+        qnaListScreenGlobalKey.currentState?.searchQna(text);
+      } else {
+        faqSearchWord = text;
+        faqScreenGlobalKey.currentState?.filterFaqs(text);
+      }
     });
-    qnaListScreenGlobalKey.currentState?.searchQna(text);
   }
 
   @override
@@ -47,6 +76,7 @@ class _QuestionScreenState extends State<QuestionScreen> {
               onTap: () {
                 setState(() {
                   _selectedPageIndex = 0;
+                  _clearSearch();
                 });
               },
               child: Text(
@@ -56,11 +86,12 @@ class _QuestionScreenState extends State<QuestionScreen> {
                 ),
               ),
             ),
-            const Text('  '),
+            const SizedBox(width: 10),
             GestureDetector(
               onTap: () {
                 setState(() {
                   _selectedPageIndex = 1;
+                  _clearSearch();
                 });
               },
               child: Text(
@@ -73,7 +104,7 @@ class _QuestionScreenState extends State<QuestionScreen> {
           ],
         ),
         actions: [
-          if (qnaSearchWord.isNotEmpty)
+          if (_selectedPageIndex == 0 && qnaSearchWord.isNotEmpty)
             Padding(
               padding: const EdgeInsets.only(right: 8.0),
               child: Chip(
@@ -97,26 +128,56 @@ class _QuestionScreenState extends State<QuestionScreen> {
                 side: BorderSide.none,
               ),
             ),
+          if (_selectedPageIndex == 1)
+            SizedBox(
+              width: 200,
+              child: TextField(
+                controller: _searchController,
+                onChanged: (text) {
+                  _performSearch(text);
+                },
+                decoration: InputDecoration(
+                  hintText: "검색어를 입력하세요",
+                  border: InputBorder.none,
+                  hintStyle: const TextStyle(
+                    color: Color(0XFFd7d7d7),
+                  ),
+                  suffixIcon: _searchController.text.isNotEmpty
+                      ? IconButton(
+                          onPressed: () {
+                            _clearSearch();
+                          },
+                          icon: const Icon(
+                            Icons.cancel,
+                            color: Colors.grey,
+                          ),
+                        )
+                      : null,
+                ),
+                style: const TextStyle(
+                  color: Colors.black,
+                  fontSize: 18.0,
+                ),
+              ),
+            ),
           IconButton(
             icon: Icon(
               Icons.search,
               color: Theme.of(context).primaryColor,
             ),
             onPressed: () {
-              // QNA 검색
               if (_selectedPageIndex == 0) {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                      builder: (context) => SearchScreen(
-                            searchCallback: (text) {
-                              _performSearch(text);
-                            },
-                          )),
+                    builder: (context) => SearchScreen(
+                      searchCallback: (text) {
+                        _performSearch(text);
+                      },
+                    ),
+                  ),
                 );
               }
-              // FAQ 검색
-              else {}
             },
           ),
         ],

--- a/front/capstone_front/lib/screens/question/question_screen.dart
+++ b/front/capstone_front/lib/screens/question/question_screen.dart
@@ -2,7 +2,6 @@ import 'package:capstone_front/screens/faq/faq_screen.dart';
 import 'package:capstone_front/screens/qna/qna_list_screen/qna_list_screen.dart';
 import 'package:capstone_front/utils/search_screen.dart';
 import 'package:flutter/material.dart';
-import 'package:capstone_front/screens/qna/qna_list_screen/qna_list_screen.dart';
 import 'package:go_router/go_router.dart';
 
 class QuestionScreen extends StatefulWidget {
@@ -19,7 +18,22 @@ class _QuestionScreenState extends State<QuestionScreen> {
     const FaqScreen(),
   ];
 
-  String qnaSearchWord = 'what';
+  String qnaSearchWord = '';
+  final _searchController = TextEditingController();
+
+  void _clearSearch() {
+    setState(() {
+      qnaSearchWord = '';
+    });
+    qnaListScreenGlobalKey.currentState?.searchQna('');
+  }
+
+  void _performSearch(String text) {
+    setState(() {
+      qnaSearchWord = text;
+    });
+    qnaListScreenGlobalKey.currentState?.searchQna(text);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -59,6 +73,30 @@ class _QuestionScreenState extends State<QuestionScreen> {
           ],
         ),
         actions: [
+          if (qnaSearchWord.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(right: 8.0),
+              child: Chip(
+                label: Text(
+                  qnaSearchWord,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                backgroundColor: const Color(0xFF6E2FF4),
+                deleteIcon: const Icon(
+                  Icons.close,
+                  color: Colors.white,
+                  size: 18,
+                ),
+                onDeleted: _clearSearch,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                side: BorderSide.none,
+              ),
+            ),
           IconButton(
             icon: Icon(
               Icons.search,
@@ -72,8 +110,7 @@ class _QuestionScreenState extends State<QuestionScreen> {
                   MaterialPageRoute(
                       builder: (context) => SearchScreen(
                             searchCallback: (text) {
-                              qnaListScreenGlobalKey.currentState
-                                  ?.searchQna(text);
+                              _performSearch(text);
                             },
                           )),
                 );


### PR DESCRIPTION
## Overview

> QnA 리팩토링

### Related Issue

Issue Number : #212 

## Task Details

- QnA 검색어 입력시 검색 버튼 옆에 태그를 띄워, 현재 검색중이라는 것을 직관적으로 알게함
- 해당 태그 오른쪽의 X버튼을 누르면 검색모드가 해제되고, 검색어를 적용하지 않은 상태의 결과를 가져옴
- FAQ에서 검색어를 입력시 실시간으로 해당 검색어가 포함된 글을 가져옴. 이때 검색 범위는 제목과 본문내용 모두를 포함함

## Screenshots (Optional)
<img width="250" alt="스크린샷 2024-05-17 오전 1 24 40" src="https://github.com/kookmin-sw/capstone-2024-30/assets/52407470/a834ea54-92c8-4593-b720-1e3062215f20">
<img width="250" alt="스크린샷 2024-05-17 오전 1 22 34" src="https://github.com/kookmin-sw/capstone-2024-30/assets/52407470/d9ac3cd7-74ea-4110-b855-b37e265d02a8">
<img width="250" alt="스크린샷 2024-05-17 오전 1 22 38" src="https://github.com/kookmin-sw/capstone-2024-30/assets/52407470/ce511c13-13f8-4673-8c49-dad86bca09f4">

## Test Scope & Checklist (Optional)

> Please explain test scope, task, plan, method
- [ ] QnA 검색시 해당 검색어가 검색버튼 왼쪽에 태그로 잘 뜨는지
- [ ] 해당 검색어가 포함된 제목의 글들이 잘 보이는지
- [ ] 검색상태에서, 학사안내, 대학생활 같은 카테고리를 선택하여도 해당 검색어가 적용된 상태인지
- [ ] 검색어를 삭제하였을 때, 전체결과를 제대로 다시 가져오는지
- [ ] 검색어가 입력된 상태에서 FAQ화면으로 넘어갔을 때 정상적으로 사라지는지
- [ ] FAQ 화면에서 검색어를 입력했을 때 실시간으로 검색어에 반응하여 Listview의 내용이 바뀌는지
- [ ] FAQ 화면에서 검색어를 입력한 상태에서 다른 카테고리를 선택해도 해당 검색어가 적용된 상태의 listview가 나오는지
- [ ] FAQ 화면에서 검색어를 삭제하였을 때 정삭적으로 전체의 내용이 다시 나오는지